### PR TITLE
feat: Add Open in Okashi button for real compilation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1288,7 +1287,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1299,7 +1297,8 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -1374,7 +1373,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1540,6 +1538,7 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -1843,6 +1842,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -2526,7 +2526,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2578,7 +2577,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2591,7 +2589,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3013,7 +3010,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/src/pages/MissionDetail.jsx
+++ b/src/pages/MissionDetail.jsx
@@ -6,6 +6,7 @@ import { getMissionById, getNextMission } from '../systems/missionLoader';
 import { runTests } from '../systems/testRunner';
 import { loadProgress, saveProgress } from '../systems/storage';
 import { completeMission, recordAttempt, getXPProgress, getRankTitle } from '../systems/gameEngine';
+import { useokashi, TOAST_STATES } from '../systems/useokashi';
 
 export default function MissionDetail() {
     const { missionId } = useParams();
@@ -19,6 +20,7 @@ export default function MissionDetail() {
     const [victoryData, setVictoryData] = useState(null);
     const [hintIndex, setHintIndex] = useState(-1);
     const terminalBodyRef = useRef(null);
+    const { openInOkashi, toast } = useokashi();
 
     useEffect(() => {
         if (mission) {
@@ -262,7 +264,7 @@ export default function MissionDetail() {
                 </div>
             </div>
 
-            {/* Victory Modal */}
+            {/* Victory Modal — only shows when ALL tests pass */}
             {showVictory && victoryData && (
                 <div className="modal-overlay" onClick={() => setShowVictory(false)}>
                     <div className="modal-content" onClick={(e) => e.stopPropagation()}>
@@ -272,16 +274,20 @@ export default function MissionDetail() {
                             You've completed <strong>{mission.title}</strong>
                         </p>
                         <div className="modal-xp">+{victoryData.xp} XP</div>
+
                         {victoryData.leveledUp && (
                             <p style={{ color: 'var(--purple)', fontFamily: 'var(--font-display)', marginBottom: '1rem' }}>
                                 🎉 Level Up! You are now Level {victoryData.newLevel} — {getRankTitle(victoryData.newLevel)}
                             </p>
                         )}
+
                         {victoryData.newBadges?.length > 0 && (
                             <p style={{ color: 'var(--gold)', marginBottom: '1rem' }}>
                                 🏅 New badge{victoryData.newBadges.length > 1 ? 's' : ''} earned!
                             </p>
                         )}
+
+                        {/* Navigation Buttons */}
                         <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center' }}>
                             <button className="btn btn-primary" onClick={handleNextMission}>
                                 Next Mission →
@@ -290,6 +296,67 @@ export default function MissionDetail() {
                                 Mission Map
                             </button>
                         </div>
+
+                        {/* ── Okashi Button ── only visible after mission completion ── */}
+                        <div style={{
+                            marginTop: '1.25rem',
+                            paddingTop: '1.25rem',
+                            borderTop: '1px solid rgba(255,255,255,0.08)',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'center',
+                            gap: '8px',
+                        }}>
+                            <button
+                                onClick={() => openInOkashi(code)}
+                                style={{
+                                    padding: '10px 22px',
+                                    borderRadius: '8px',
+                                    border: 'none',
+                                    background: 'linear-gradient(135deg, #7c3aed, #2563eb)',
+                                    color: '#fff',
+                                    fontSize: '14px',
+                                    fontWeight: '700',
+                                    cursor: 'pointer',
+                                    boxShadow: '0 4px 14px rgba(124,58,237,0.4)',
+                                    transition: 'opacity 0.2s',
+                                }}
+                                onMouseEnter={e => e.target.style.opacity = '0.85'}
+                                onMouseLeave={e => e.target.style.opacity = '1'}
+                            >
+                                🚀 Try on Okashi — Compile &amp; Deploy
+                            </button>
+
+                            <p style={{
+                                fontSize: '11px',
+                                color: '#94a3b8',
+                                textAlign: 'center',
+                                maxWidth: '300px',
+                                margin: 0,
+                                lineHeight: '1.5',
+                            }}>
+                                Opens okashi.dev in a new tab. Your code is copied to clipboard — paste it there to compile with the real Soroban compiler and deploy to Testnet.
+                            </p>
+
+                            {/* Toast notification */}
+                            {toast.state !== TOAST_STATES.IDLE && (
+                                <div style={{
+                                    padding: '10px 16px',
+                                    borderRadius: '8px',
+                                    fontSize: '13px',
+                                    fontWeight: '500',
+                                    background: toast.state === TOAST_STATES.SUCCESS ? '#064e3b' : '#4c0519',
+                                    color: toast.state === TOAST_STATES.SUCCESS ? '#6ee7b7' : '#fda4af',
+                                    border: toast.state === TOAST_STATES.SUCCESS ? '1px solid #065f46' : '1px solid #881337',
+                                    maxWidth: '340px',
+                                    textAlign: 'center',
+                                    lineHeight: '1.5',
+                                }}>
+                                    {toast.message}
+                                </div>
+                            )}
+                        </div>
+
                     </div>
                 </div>
             )}

--- a/src/systems/useokashi.js
+++ b/src/systems/useokashi.js
@@ -1,0 +1,42 @@
+import { useState, useCallback } from "react";
+
+export const TOAST_STATES = {
+  IDLE: "idle",
+  SUCCESS: "success",
+  ERROR: "error",
+};
+
+export function useokashi() {
+  const [toast, setToast] = useState({ 
+    state: TOAST_STATES.IDLE, 
+    message: "" 
+  });
+
+  const openInOkashi = useCallback(async (code) => {
+    // Step 1: Copy code to clipboard
+    try {
+      await navigator.clipboard.writeText(code);
+      // Step 2: Open Okashi in new tab
+      window.open("https://okashi.dev", "_blank", "noopener,noreferrer");
+      // Step 3: Show success message
+      setToast({
+        state: TOAST_STATES.SUCCESS,
+        message: "✅ Code copied! Paste it in Okashi (Ctrl+V) to compile & deploy to Testnet 🚀",
+      });
+    } catch {
+      // Clipboard failed — still open Okashi
+      window.open("https://okashi.dev", "_blank", "noopener,noreferrer");
+      setToast({
+        state: TOAST_STATES.ERROR,
+        message: "⚠️ Okashi opened! Auto-copy failed — please copy your code manually and paste it there.",
+      });
+    }
+
+    // Auto-clear the toast after 6 seconds
+    setTimeout(() => {
+      setToast({ state: TOAST_STATES.IDLE, message: "" });
+    }, 6000);
+  }, []);
+
+  return { openInOkashi, toast };
+}


### PR DESCRIPTION
Closes #12

## Summary
Adds an "Open in Okashi" button that appears in the victory modal after 
a learner successfully completes a mission. Clicking it copies their 
solution code to the clipboard and opens okashi.dev in a new tab, 
allowing them to compile with the real Soroban compiler and deploy 
to Stellar Testnet — no backend required.

## Changes
- Created `src/systems/useOkashi.js` — custom hook that handles 
  clipboard copy and opening Okashi.dev
- Updated `src/pages/MissionDetail.jsx` — added Okashi button 
  inside the victory modal

## How it works
- Okashi.dev has no public URL parameter for pre-filling code
- So we use `navigator.clipboard.writeText(code)` to copy the code
- Then open `https://okashi.dev` in a new tab
- A toast notification tells the learner to paste their code there

## Verification
- ✅ Button appears only after all mission checks pass
- ✅ Button does NOT appear for incomplete missions  
- ✅ Clicking opens Okashi.dev in a new tab
- ✅ Code is copied to clipboard (confirmed by pasting)
- ✅ Toast message guides the learner on what to do next
- ✅ Tested on Mission 1 ("The First Contract")
- ✅ `npm run build` passes with no errors — 216 modules, built in 4.05s

## Screenshot


<img width="1903" height="874" alt="Screenshot 2026-02-22 233215" src="https://github.com/user-attachments/assets/2c84e4ad-1f59-4c44-bd3b-b7786903af04" />
