### PR TITLE
feat:add themed 404 not found page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,23 +1,25 @@
-import React from 'react';
-import { Routes, Route } from 'react-router-dom';
-import Navbar from './components/Navbar';
-import Home from './pages/Home';
-import MissionMap from './pages/MissionMap';
-import MissionDetail from './pages/MissionDetail';
-import Profile from './pages/Profile';
+import React from "react";
+import { Routes, Route } from "react-router-dom";
+import Navbar from "./components/Navbar";
+import Home from "./pages/Home";
+import MissionMap from "./pages/MissionMap";
+import MissionDetail from "./pages/MissionDetail";
+import Profile from "./pages/Profile";
+import NotFound from "./pages/NotFound";
 
 export default function App() {
-    return (
-        <div className="app">
-            <Navbar />
-            <main className="main-content">
-                <Routes>
-                    <Route path="/" element={<Home />} />
-                    <Route path="/missions" element={<MissionMap />} />
-                    <Route path="/mission/:missionId" element={<MissionDetail />} />
-                    <Route path="/profile" element={<Profile />} />
-                </Routes>
-            </main>
-        </div>
-    );
+  return (
+    <div className="app">
+      <Navbar />
+      <main className="main-content">
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/missions" element={<MissionMap />} />
+          <Route path="/mission/:missionId" element={<MissionDetail />} />
+          <Route path="/profile" element={<Profile />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </main>
+    </div>
+  );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,7 @@
    RPG-inspired dark theme for Stellar/Soroban
    ========================================== */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&family=Orbitron:wght@400;500;600;700;800;900&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&family=Orbitron:wght@400;500;600;700;800;900&display=swap");
 
 :root {
   /* Core palette */
@@ -12,7 +12,7 @@
   --bg-tertiary: #1a2236;
   --bg-card: rgba(17, 24, 39, 0.7);
   --bg-glass: rgba(17, 24, 39, 0.5);
-  
+
   /* Accent colors */
   --cyan: #06d6a0;
   --cyan-dim: rgba(6, 214, 160, 0.15);
@@ -29,23 +29,23 @@
   --green-dim: rgba(34, 197, 94, 0.15);
   --blue: #3b82f6;
   --blue-dim: rgba(59, 130, 246, 0.15);
-  
+
   /* Text */
   --text-primary: #f1f5f9;
   --text-secondary: #94a3b8;
   --text-muted: #64748b;
   --text-accent: var(--cyan);
-  
+
   /* Borders */
   --border-subtle: rgba(148, 163, 184, 0.1);
   --border-accent: rgba(6, 214, 160, 0.3);
   --border-glow: rgba(6, 214, 160, 0.6);
-  
+
   /* Typography */
-  --font-body: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-  --font-code: 'JetBrains Mono', 'Fira Code', monospace;
-  --font-display: 'Orbitron', sans-serif;
-  
+  --font-body: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-code: "JetBrains Mono", "Fira Code", monospace;
+  --font-display: "Orbitron", sans-serif;
+
   /* Spacing */
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
@@ -54,27 +54,29 @@
   --space-xl: 2rem;
   --space-2xl: 3rem;
   --space-3xl: 4rem;
-  
+
   /* Radii */
   --radius-sm: 6px;
   --radius-md: 10px;
   --radius-lg: 16px;
   --radius-xl: 20px;
   --radius-full: 9999px;
-  
+
   /* Shadows */
   --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.3);
   --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.4);
   --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
   --shadow-glow-cyan: 0 0 20px var(--cyan-glow), 0 0 60px rgba(6, 214, 160, 0.1);
-  --shadow-glow-purple: 0 0 20px var(--purple-glow), 0 0 60px rgba(139, 92, 246, 0.1);
-  --shadow-glow-gold: 0 0 20px var(--gold-glow), 0 0 60px rgba(245, 158, 11, 0.1);
-  
+  --shadow-glow-purple: 0 0 20px var(--purple-glow),
+    0 0 60px rgba(139, 92, 246, 0.1);
+  --shadow-glow-gold: 0 0 20px var(--gold-glow),
+    0 0 60px rgba(245, 158, 11, 0.1);
+
   /* Transitions */
   --transition-fast: 150ms ease;
   --transition-base: 250ms ease;
   --transition-slow: 400ms ease;
-  
+
   /* Z-indices */
   --z-navbar: 100;
   --z-modal: 200;
@@ -82,7 +84,9 @@
 }
 
 /* ============ RESET ============ */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
@@ -106,17 +110,28 @@ body {
 
 /* Animated background */
 body::before {
-  content: '';
+  content: "";
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
   z-index: -1;
-  background: 
-    radial-gradient(ellipse at 20% 50%, rgba(6, 214, 160, 0.03) 0%, transparent 50%),
-    radial-gradient(ellipse at 80% 20%, rgba(139, 92, 246, 0.04) 0%, transparent 50%),
-    radial-gradient(ellipse at 50% 80%, rgba(59, 130, 246, 0.03) 0%, transparent 50%),
+  background: radial-gradient(
+      ellipse at 20% 50%,
+      rgba(6, 214, 160, 0.03) 0%,
+      transparent 50%
+    ),
+    radial-gradient(
+      ellipse at 80% 20%,
+      rgba(139, 92, 246, 0.04) 0%,
+      transparent 50%
+    ),
+    radial-gradient(
+      ellipse at 50% 80%,
+      rgba(59, 130, 246, 0.03) 0%,
+      transparent 50%
+    ),
     var(--bg-primary);
   pointer-events: none;
 }
@@ -126,9 +141,14 @@ a {
   text-decoration: none;
   transition: color var(--transition-fast);
 }
-a:hover { color: var(--text-primary); }
+a:hover {
+  color: var(--text-primary);
+}
 
-img { max-width: 100%; display: block; }
+img {
+  max-width: 100%;
+  display: block;
+}
 
 button {
   cursor: pointer;
@@ -206,7 +226,7 @@ button {
 }
 
 .navbar-links a::after {
-  content: '';
+  content: "";
   position: absolute;
   bottom: -2px;
   left: 0;
@@ -379,19 +399,28 @@ button {
 }
 
 .xp-bar-fill::after {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.3) 50%, transparent 100%);
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.3) 50%,
+    transparent 100%
+  );
   animation: xpShimmer 2s infinite;
 }
 
 @keyframes xpShimmer {
-  0% { transform: translateX(-100%); }
-  100% { transform: translateX(100%); }
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
 }
 
 .xp-bar-label {
@@ -465,9 +494,15 @@ button {
   border-radius: 50%;
 }
 
-.terminal-dot.red { background: #ff5f56; }
-.terminal-dot.yellow { background: #ffbd2e; }
-.terminal-dot.green { background: #27c93f; }
+.terminal-dot.red {
+  background: #ff5f56;
+}
+.terminal-dot.yellow {
+  background: #ffbd2e;
+}
+.terminal-dot.green {
+  background: #27c93f;
+}
 
 .terminal-title {
   color: var(--text-muted);
@@ -505,8 +540,14 @@ button {
 }
 
 @keyframes terminalFadeIn {
-  from { opacity: 0; transform: translateY(4px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* ============ MISSION CARD ============ */
@@ -522,7 +563,7 @@ button {
 }
 
 .mission-card::before {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: 0;
@@ -683,7 +724,12 @@ button {
 }
 
 .hero-title-gradient {
-  background: linear-gradient(135deg, var(--cyan) 0%, var(--purple) 50%, var(--gold) 100%);
+  background: linear-gradient(
+    135deg,
+    var(--cyan) 0%,
+    var(--purple) 50%,
+    var(--gold) 100%
+  );
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -731,8 +777,14 @@ button {
 }
 
 @keyframes fadeSlideUp {
-  from { opacity: 0; transform: translateY(20px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* ============ FEATURES SECTION ============ */
@@ -1167,13 +1219,23 @@ button {
 }
 
 @keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes scaleIn {
-  from { opacity: 0; transform: scale(0.8); }
-  to { opacity: 1; transform: scale(1); }
+  from {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 /* ============ SCROLLBAR ============ */
@@ -1205,7 +1267,9 @@ button {
 }
 
 @keyframes spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* ============ RESPONSIVE ============ */
@@ -1214,13 +1278,13 @@ button {
     grid-template-columns: 1fr;
     grid-template-rows: auto 1fr auto;
   }
-  
+
   .mission-story {
     max-height: 300px;
     border-right: none;
     border-bottom: 1px solid var(--border-subtle);
   }
-  
+
   .navbar-links {
     display: none;
   }
@@ -1235,16 +1299,16 @@ button {
   .hero-title {
     font-size: 2rem;
   }
-  
+
   .hero-actions {
     flex-direction: column;
   }
-  
+
   .profile-header {
     flex-direction: column;
     text-align: center;
   }
-  
+
   .mission-map-grid {
     grid-template-columns: 1fr;
   }
@@ -1252,7 +1316,6 @@ button {
 
 /* MOBILE STYLES  (768px and below) */
 @media (max-width: 768px) {
-
   /* Show the tab bar */
   .mobile-tabs {
     display: flex;
@@ -1295,15 +1358,15 @@ button {
   }
 
   /* Active tab indicator — driven entirely by :checked, no JS */
-  #tab-story:checked  ~ .mobile-tabs label[for="tab-story"],
+  #tab-story:checked ~ .mobile-tabs label[for="tab-story"],
   #tab-editor:checked ~ .mobile-tabs label[for="tab-editor"],
-  #tab-tests:checked  ~ .mobile-tabs label[for="tab-tests"] {
+  #tab-tests:checked ~ .mobile-tabs label[for="tab-tests"] {
     color: var(--cyan);
   }
 
-  #tab-story:checked  ~ .mobile-tabs label[for="tab-story"]::after,
+  #tab-story:checked ~ .mobile-tabs label[for="tab-story"]::after,
   #tab-editor:checked ~ .mobile-tabs label[for="tab-editor"]::after,
-  #tab-tests:checked  ~ .mobile-tabs label[for="tab-tests"]::after {
+  #tab-tests:checked ~ .mobile-tabs label[for="tab-tests"]::after {
     width: 100%;
   }
 
@@ -1388,5 +1451,65 @@ button {
   /* Run Tests button meets 44px minimum tap target */
   .btn-sm {
     min-height: 44px;
+  }
+}
+
+/* 404 PAGE */
+.not-found {
+  min-height: calc(100vh - 70px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: var(--space-xl);
+  gap: var(--space-md);
+}
+
+.not-found-astronaut {
+  font-size: 5rem;
+  animation: drift 4s ease-in-out infinite;
+}
+
+.not-found-code {
+  font-family: var(--font-display);
+  font-size: clamp(5rem, 15vw, 9rem);
+  font-weight: 900;
+  background: linear-gradient(135deg, var(--cyan), var(--purple));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  line-height: 1;
+}
+
+.not-found-title {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.not-found-sub {
+  color: var(--text-secondary);
+  max-width: 400px;
+  font-size: 0.95rem;
+}
+
+@keyframes drift {
+  0%,
+  100% {
+    transform: translateY(0) rotate(-5deg);
+  }
+  50% {
+    transform: translateY(-20px) rotate(5deg);
+  }
+}
+
+@media (max-width: 375px) {
+  .not-found-code {
+    font-size: 4rem;
+  }
+  .not-found-astronaut {
+    font-size: 3.5rem;
   }
 }

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+export default function NotFound() {
+  return (
+    <div className="not-found">
+      <div className="not-found-astronaut">🧑‍🚀</div>
+      <h1 className="not-found-code">404</h1>
+      <p className="not-found-title">Quest Not Found</p>
+      <p className="not-found-sub">
+        This sector of space is uncharted. The Quest you seek does not exist.
+      </p>
+      <Link to="/" className="btn btn-primary">
+        ⬅ Return to Base
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## What does this PR do?
Adds a themed 404 Not Found page for invalid routes. Previously, navigating to any undefined route rendered a blank page with only the Navbar visible. This PR creates a fully styled NotFound.jsx page consistent with the existing dark RPG aesthetic, complete with an animated floating astronaut, thematic copy, and a "Return to Base" button linking back to Home.

## Related issue
Closes #29

## Type of change

- [x ] New feature






