### PR TITLE
feat(editor): add multi-file tabbed editor with backward compatibility

### DIFF
--- a/src/data/missions.js
+++ b/src/data/missions.js
@@ -65,6 +65,63 @@ impl HelloContract {
         vec![&env, symbol_short!("Hello"), to]
     }
 }`,
+        files: [
+            {
+                name: 'lib.rs',
+                language: 'rust',
+                template: `#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, vec, Env, Symbol, Vec};
+
+#[contract]
+pub struct HelloContract;
+
+#[contractimpl]
+impl HelloContract {
+    // TODO: Create a public function called 'hello'
+    // It should take two parameters: env: Env, to: Symbol
+    // It should return Vec<Symbol>
+    // The function should return a vector containing
+    // the symbols "Hello" and the 'to' parameter
+
+}`,
+                solution: `#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, vec, Env, Symbol, Vec};
+
+#[contract]
+pub struct HelloContract;
+
+#[contractimpl]
+impl HelloContract {
+    pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
+        vec![&env, symbol_short!("Hello"), to]
+    }
+}`,
+            },
+            {
+                name: 'Cargo.toml',
+                language: 'toml',
+                template: `[package]
+name = "hello-soroban"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "21.0.0", features = ["alloc"] }`,
+                solution: `[package]
+name = "hello-soroban"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "21.0.0", features = ["alloc"] }`,
+            },
+        ],
         checks: [
             { type: 'has_attribute', attribute: 'contract', message: 'Missing #[contract] attribute on your struct', description: '#[contract] attribute' },
             { type: 'has_attribute', attribute: 'contractimpl', message: 'Missing #[contractimpl] on your impl block', description: '#[contractimpl] attribute' },

--- a/src/index.css
+++ b/src/index.css
@@ -1147,6 +1147,11 @@ button {
   background: var(--cyan);
 }
 
+.editor-file-tab:hover {
+  opacity: 0.8 !important;
+  background: var(--bg-secondary);
+}
+
 .editor-wrapper {
   flex: 1;
   overflow: hidden;

--- a/src/pages/MissionDetail.jsx
+++ b/src/pages/MissionDetail.jsx
@@ -19,9 +19,22 @@ export default function MissionDetail() {
   const navigate = useNavigate();
   const mission = getMissionById(missionId);
 
+  // --------------------------- Helpers ---------------------------
+  function getMissionFiles(m) {
+    if (m.files && m.files.length > 0) return m.files;
+    return [{ name: 'lib.rs', language: 'rust', template: m.template, solution: m.solution }];
+  }
+
+  function fileIcon(name) {
+    if (name.endsWith('.rs')) return '🦀';
+    if (name === 'Cargo.toml' || name.endsWith('.toml')) return '📦';
+    return '📄';
+  }
+
   // --------------------------- States ---------------------------
-  const [loading, setLoading] = useState(true); // Show skeleton while mission loads
-  const [code, setCode] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [activeFile, setActiveFile] = useState('lib.rs');
+  const [fileCodes, setFileCodes] = useState({});
   const [testResults, setTestResults] = useState([]);
   const [isRunning, setIsRunning] = useState(false);
   const [showVictory, setShowVictory] = useState(false);
@@ -35,9 +48,12 @@ export default function MissionDetail() {
   useEffect(() => {
     setLoading(true);
     if (mission) {
-      // Brief delay to display skeleton
       setTimeout(() => {
-        setCode(mission.template);
+        const files = getMissionFiles(mission);
+        const initial = {};
+        for (const f of files) initial[f.name] = f.template;
+        setFileCodes(initial);
+        setActiveFile(files[0].name);
         setTestResults([]);
         setHintIndex(-1);
         setShowVictory(false);
@@ -77,8 +93,8 @@ export default function MissionDetail() {
     addResult({ phase: "info", message: "🔍 Running validation checks..." });
     await delay(400);
 
-    // Run mission tests
-    const result = await runTests(code, mission);
+    // Run mission tests against all file codes
+    const result = await runTests(fileCodes, mission);
     for (const r of result.results) {
       addResult(r);
       await delay(250);
@@ -111,7 +127,7 @@ export default function MissionDetail() {
     }
 
     setIsRunning(false);
-  }, [code, mission, missionId, isRunning]);
+  }, [fileCodes, mission, missionId, isRunning]);
 
   // --------------------------- Hints ---------------------------
   const handleHint = () => {
@@ -123,7 +139,10 @@ export default function MissionDetail() {
   // --------------------------- Reset ---------------------------
   const handleReset = () => {
     if (mission) {
-      setCode(mission.template);
+      const files = getMissionFiles(mission);
+      const reset = {};
+      for (const f of files) reset[f.name] = f.template;
+      setFileCodes(reset);
       setTestResults([]);
       setHintIndex(-1);
     }
@@ -131,8 +150,11 @@ export default function MissionDetail() {
 
   // --------------------------- Show Solution ---------------------------
   const handleShowSolution = () => {
-    if (mission?.solution) {
-      setCode(mission.solution);
+    if (!mission) return;
+    const files = getMissionFiles(mission);
+    const file = files.find(f => f.name === activeFile);
+    if (file?.solution) {
+      setFileCodes(prev => ({ ...prev, [activeFile]: file.solution }));
     }
   };
 
@@ -239,9 +261,21 @@ export default function MissionDetail() {
         <div className="mission-editor-panel">
           <div className="mission-editor-toolbar">
             <div className="mission-editor-toolbar-left">
-              <div className="editor-file-tab">
-                <span className="dot" /> lib.rs
-              </div>
+              {getMissionFiles(mission).map((f) => (
+                <button
+                  key={f.name}
+                  className="editor-file-tab"
+                  onClick={() => setActiveFile(f.name)}
+                  style={{
+                    cursor: 'pointer',
+                    border: 'none',
+                    outline: activeFile === f.name ? '1px solid var(--cyan)' : 'none',
+                    opacity: activeFile === f.name ? 1 : 0.5,
+                  }}
+                >
+                  <span className="dot" /> {fileIcon(f.name)} {f.name}
+                </button>
+              ))}
             </div>
             <div className="mission-editor-toolbar-right">
               <button
@@ -289,9 +323,9 @@ export default function MissionDetail() {
           <div className="editor-wrapper">
             <Editor
               height="100%"
-              defaultLanguage="rust"
-              value={code}
-              onChange={(v) => setCode(v || "")}
+              language={getMissionFiles(mission).find(f => f.name === activeFile)?.language ?? 'rust'}
+              value={fileCodes[activeFile] ?? ''}
+              onChange={(v) => setFileCodes(prev => ({ ...prev, [activeFile]: v || '' }))}
               theme="vs-dark"
               options={{
                 fontSize: 14,
@@ -417,7 +451,7 @@ export default function MissionDetail() {
               }}
             >
               <button
-                onClick={() => openInOkashi(code)}
+                onClick={() => openInOkashi(fileCodes[getMissionFiles(mission)[0].name] ?? '')}
                 style={{
                   padding: "10px 22px",
                   borderRadius: "8px",

--- a/src/systems/testRunner.js
+++ b/src/systems/testRunner.js
@@ -5,14 +5,25 @@
 
 import { validateCode } from './codeValidator';
 
-export async function runTests(code, mission) {
+export async function runTests(fileCodes, mission) {
+    // Backward compat: accept plain string (single-file missions)
+    if (typeof fileCodes === 'string') {
+        fileCodes = { 'lib.rs': fileCodes };
+    }
+
+    const files = mission.files && mission.files.length > 0
+        ? mission.files
+        : [{ name: 'lib.rs' }];
+    const primaryFileName = files[0].name;
+    const primaryCode = fileCodes[primaryFileName] ?? Object.values(fileCodes)[0] ?? '';
+
     const results = [];
 
-    // Step 1: Syntax basics
+    // Step 1: Syntax basics (primary file)
     results.push({
         phase: 'syntax',
         label: '🔍 Checking syntax...',
-        ...checkSyntaxBasics(code),
+        ...checkSyntaxBasics(primaryCode),
     });
 
     await delay(300);
@@ -21,26 +32,27 @@ export async function runTests(code, mission) {
     results.push({
         phase: 'structure',
         label: '🏗️ Validating structure...',
-        ...checkStructure(code, mission),
+        ...checkStructure(primaryCode),
     });
 
     await delay(300);
 
-    // Step 3: Mission-specific checks
-    const validation = validateCode(code, mission.checks);
-
-    for (let i = 0; i < validation.results.length; i++) {
+    // Step 3: Mission-specific checks — each check routed to its target file
+    for (let i = 0; i < mission.checks.length; i++) {
         await delay(200);
+        const check = mission.checks[i];
+        const targetFile = check.file || primaryFileName;
+        const code = fileCodes[targetFile] ?? primaryCode;
+        const validation = validateCode(code, [check]);
         results.push({
             phase: 'test',
-            label: `🧪 Test ${i + 1}/${validation.totalCount}`,
-            ...validation.results[i],
+            label: `🧪 Test ${i + 1}/${mission.checks.length}`,
+            ...validation.results[0],
         });
     }
 
     await delay(300);
 
-    // Final summary
     const allPassed = results.every(r => r.passed);
     const passedCount = results.filter(r => r.passed).length;
 
@@ -91,7 +103,7 @@ function checkSyntaxBasics(code) {
     return { passed: true, message: '✓ Basic syntax looks good' };
 }
 
-function checkStructure(code, mission) {
+function checkStructure(code) {
     // Must have at least one fn declaration
     if (!/fn\s+\w+/.test(code)) {
         return { passed: false, message: '✗ No function definitions found' };


### PR DESCRIPTION
getMissionFiles() normalises any mission to a files array — missions without files fall back to a single lib.rs tab automatically (zero regression)
MissionDetail: replaced single code state with activeFile + fileCodes map; tab bar renders one clickable button per file with language icon ( .rs,  .toml) and cyan active outline
handleReset resets all files; handleShowSolution restores solution for the active tab only
testRunner.runTests now accepts fileCodes object; each check routed to check.file target (defaults to primary file) — codeValidator.js unchanged
hello-soroban mission extended with files array (lib.rs + Cargo.toml) as reference schema
Closes #40