### PR TITLE
feat: add searchable Soroban glossary page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import MissionDetail from "./pages/MissionDetail";
 import Profile from "./pages/Profile";
 import Footer from "./components/Footer";
 import NotFound from "./pages/NotFound";
+import Glossary from "./pages/Glossary";
 
 export default function App() {
   return (
@@ -18,6 +19,7 @@ export default function App() {
           <Route path="/missions" element={<MissionMap />} />
           <Route path="/mission/:missionId" element={<MissionDetail />} />
           <Route path="/profile" element={<Profile />} />
+          <Route path="/glossary" element={<Glossary />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </main>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,45 +1,67 @@
-import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
-import { loadProgress } from '../systems/storage';
-import { getRankTitle, getXPProgress } from '../systems/gameEngine';
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
+import { loadProgress } from "../systems/storage";
+import { getRankTitle, getXPProgress } from "../systems/gameEngine";
 
 export default function Navbar() {
-    const location = useLocation();
-    const state = loadProgress();
-    const xpProgress = getXPProgress(state);
+  const location = useLocation();
+  const state = loadProgress();
+  const xpProgress = getXPProgress(state);
 
-    const isActive = (path) => location.pathname === path ? 'active' : '';
+  const isActive = (path) => (location.pathname === path ? "active" : "");
 
-    return (
-        <nav className="navbar">
-            <Link to="/" className="navbar-logo">
-                <svg className="navbar-logo-icon" viewBox="0 0 36 36" fill="none">
-                    <circle cx="18" cy="18" r="16" stroke="url(#navGrad)" strokeWidth="2" />
-                    <path d="M18 6L22 14L30 16L24 22L25 30L18 26L11 30L12 22L6 16L14 14L18 6Z" fill="url(#navGrad)" />
-                    <defs>
-                        <linearGradient id="navGrad" x1="0" y1="0" x2="36" y2="36">
-                            <stop stopColor="#06d6a0" />
-                            <stop offset="1" stopColor="#8b5cf6" />
-                        </linearGradient>
-                    </defs>
-                </svg>
-                <span className="navbar-logo-text">SOROBAN QUEST</span>
-            </Link>
+  return (
+    <nav className="navbar">
+      <Link to="/" className="navbar-logo">
+        <svg className="navbar-logo-icon" viewBox="0 0 36 36" fill="none">
+          <circle
+            cx="18"
+            cy="18"
+            r="16"
+            stroke="url(#navGrad)"
+            strokeWidth="2"
+          />
+          <path
+            d="M18 6L22 14L30 16L24 22L25 30L18 26L11 30L12 22L6 16L14 14L18 6Z"
+            fill="url(#navGrad)"
+          />
+          <defs>
+            <linearGradient id="navGrad" x1="0" y1="0" x2="36" y2="36">
+              <stop stopColor="#06d6a0" />
+              <stop offset="1" stopColor="#8b5cf6" />
+            </linearGradient>
+          </defs>
+        </svg>
+        <span className="navbar-logo-text">SOROBAN QUEST</span>
+      </Link>
 
-            <ul className="navbar-links">
-                <li><Link to="/" className={isActive('/')}>Home</Link></li>
-                <li><Link to="/missions" className={isActive('/missions')}>Missions</Link></li>
-                <li><Link to="/profile" className={isActive('/profile')}>Profile</Link></li>
-            </ul>
+      <ul className="navbar-links">
+        <li>
+          <Link to="/" className={isActive("/")}>
+            Home
+          </Link>
+        </li>
+        <li>
+          <Link to="/missions" className={isActive("/missions")}>
+            Missions
+          </Link>
+        </li>
+        <li>
+          <Link to="/glossary" className={isActive("/glossary")}>
+            Glossary
+          </Link>
+        </li>
+        <li>
+          <Link to="/profile" className={isActive("/profile")}>
+            Profile
+          </Link>
+        </li>
+      </ul>
 
-            <div className="navbar-stats">
-                <div className="navbar-xp">
-                    ⚡ {state.xp} XP
-                </div>
-                <div className="navbar-level">
-                    🛡️ Lv.{state.level}
-                </div>
-            </div>
-        </nav>
-    );
+      <div className="navbar-stats">
+        <div className="navbar-xp">⚡ {state.xp} XP</div>
+        <div className="navbar-level">🛡️ Lv.{state.level}</div>
+      </div>
+    </nav>
+  );
 }

--- a/src/data/glossary.js
+++ b/src/data/glossary.js
@@ -1,0 +1,315 @@
+export const glossaryTerms = [
+  {
+    name: "#[contract]",
+    category: "Attributes",
+    description:
+      "Marks a Rust struct as a Soroban smart contract. Required on the struct that represents your contract.",
+    code: `#[contract]
+  pub struct HelloContract;`,
+    missions: ["hello-soroban"],
+  },
+  {
+    name: "#[contractimpl]",
+    category: "Attributes",
+    description:
+      "Marks an impl block as containing the contract's public functions. All callable contract methods go inside this block.",
+    code: `#[contractimpl]
+  impl HelloContract {
+      pub fn hello(env: Env, to: Symbol) -> Vec<Symbol> {
+          vec![&env, symbol_short!("Hello"), to]
+      }
+  }`,
+    missions: ["hello-soroban", "greetings-protocol"],
+  },
+  {
+    name: "Env",
+    category: "Types",
+    description:
+      "The execution environment passed to every contract function. Provides access to storage, ledger info, events, and more.",
+    code: `pub fn my_fn(env: Env) {
+      let seq = env.ledger().sequence();
+      env.storage().instance().set(&KEY, &value);
+  }`,
+    missions: ["hello-soroban"],
+  },
+  {
+    name: "Symbol",
+    category: "Types",
+    description:
+      "A small, efficient string-like type in Soroban. Used for short identifiers, storage keys, and return values.",
+    code: `use soroban_sdk::Symbol;
+  const KEY: Symbol = symbol_short!("COUNTER");`,
+    missions: ["hello-soroban", "counter-vault"],
+  },
+  {
+    name: "Vec",
+    category: "Types",
+    description:
+      "A Soroban-native vector type. Created using the vec![] macro with &env as the first argument.",
+    code: `use soroban_sdk::Vec;
+  let v: Vec<Symbol> = vec![&env, symbol_short!("Hello"), to];`,
+    missions: ["hello-soroban"],
+  },
+  {
+    name: "String",
+    category: "Types",
+    description:
+      "Full string type in Soroban for longer text values. Supports .len() to get character count.",
+    code: `use soroban_sdk::String;
+  pub fn count_chars(env: Env, text: String) -> u32 {
+      text.len()
+  }`,
+    missions: ["greetings-protocol"],
+  },
+  {
+    name: "u32",
+    category: "Types",
+    description:
+      "Unsigned 32-bit integer. Commonly used for counts, sequence numbers, and small numeric values.",
+    code: `pub fn get_count(env: Env) -> u32 {
+      env.storage().instance().get(&COUNTER).unwrap_or(0)
+  }`,
+    missions: ["greetings-protocol", "counter-vault"],
+  },
+  {
+    name: "i128",
+    category: "Types",
+    description:
+      "Signed 128-bit integer. The standard type for token balances and large numeric values in Soroban.",
+    code: `let balance: i128 = env.storage().persistent().get(&account).unwrap_or(0);`,
+    missions: ["token-forge"],
+  },
+  {
+    name: "Address",
+    category: "Types",
+    description:
+      "Represents a Stellar account or contract identity. Used for access control and identifying users.",
+    code: `use soroban_sdk::Address;
+  pub fn register(env: Env, who: Address, name: Symbol) {
+      who.require_auth();
+  }`,
+    missions: ["guardian-ledger", "token-forge"],
+  },
+  {
+    name: "storage().instance()",
+    category: "Storage",
+    description:
+      "Instance storage is tied to the contract instance lifetime. Best for contract-wide configuration and counters.",
+    code: `// Write
+  env.storage().instance().set(&KEY, &value);
+  // Read
+  let val: u32 = env.storage().instance().get(&KEY).unwrap_or(0);
+  // Delete
+  env.storage().instance().remove(&KEY);`,
+    missions: ["counter-vault", "guardian-ledger"],
+  },
+  {
+    name: "storage().persistent()",
+    category: "Storage",
+    description:
+      "Persistent storage survives beyond the contract instance. Used for per-user data like token balances.",
+    code: `// Store a balance
+  env.storage().persistent().set(&address, &amount);
+  // Read a balance
+  let bal: i128 = env.storage().persistent().get(&address).unwrap_or(0);`,
+    missions: ["token-forge"],
+  },
+  {
+    name: "unwrap_or()",
+    category: "Storage",
+    description:
+      "Safely unwraps an Option returned by storage.get(). Provides a default value when no data exists yet.",
+    code: `let count: u32 = env.storage().instance()
+      .get(&COUNTER)
+      .unwrap_or(0); // default to 0 if not set`,
+    missions: ["counter-vault"],
+  },
+  {
+    name: "require_auth()",
+    category: "Auth",
+    description:
+      "Asserts that the given Address has authorized the current contract invocation. Panics if not authorized.",
+    code: `pub fn register(env: Env, who: Address, name: Symbol) {
+      who.require_auth(); // panics if 'who' didn't sign
+      env.storage().instance().set(&who, &name);
+  }`,
+    missions: [
+      "guardian-ledger",
+      "token-forge",
+      "time-lock",
+      "multi-party-pact",
+    ],
+  },
+  {
+    name: "ledger().sequence()",
+    category: "Functions",
+    description:
+      "Returns the current ledger sequence number. Used for time-based logic like locks and expiry.",
+    code: `let current: u32 = env.ledger().sequence();
+  if current < unlock_at {
+      panic!("Still locked");
+  }`,
+    missions: ["time-lock"],
+  },
+  {
+    name: "panic!()",
+    category: "Functions",
+    description:
+      "Aborts contract execution with an error message. Used for enforcing conditions and error handling.",
+    code: `if current_seq < unlock_at {
+      panic!("Still locked");
+  }`,
+    missions: ["time-lock"],
+  },
+  {
+    name: "symbol_short!()",
+    category: "Functions",
+    description:
+      "Macro that creates a Symbol from a short string literal (max 9 characters). Used for storage keys.",
+    code: `const COUNTER: Symbol = symbol_short!("COUNTER");
+  let greeting = symbol_short!("Hello");`,
+    missions: ["hello-soroban", "counter-vault"],
+  },
+  {
+    name: "vec![]",
+    category: "Functions",
+    description:
+      "Macro to create a Soroban Vec. Always pass &env as the first argument.",
+    code: `let result = vec![&env, symbol_short!("Hello"), to];`,
+    missions: ["hello-soroban"],
+  },
+  {
+    name: "multiple functions",
+    category: "Functions",
+    description:
+      "A single contract can expose multiple public functions. Each function is independently callable and can have different parameters and return types.",
+    code: `#[contractimpl]
+impl GreetingContract {
+    pub fn greet(env: Env, name: Symbol) -> Vec<Symbol> {
+        vec![&env, symbol_short!("Greetings"), name]
+    }
+
+    pub fn count_chars(env: Env, text: String) -> u32 {
+        text.len()
+    }
+}`,
+    missions: ["greetings-protocol"],
+  },
+  {
+    name: "Map",
+    category: "Types",
+    description:
+      "A key-value mapping type in Soroban. Used to associate one value with another, such as an Address to a Symbol.",
+    code: `use soroban_sdk::Map;
+let mut map: Map<Address, Symbol> = Map::new(&env);
+map.set(address, symbol_short!("Guardian"));`,
+    missions: ["guardian-ledger"],
+  },
+  {
+    name: "bool",
+    category: "Types",
+    description:
+      "Boolean type. Used for true/false return values such as checking if a condition is met.",
+    code: `pub fn is_complete(env: Env) -> bool {
+    let signed: u32 = env.storage().instance().get(&SIGNED).unwrap_or(0);
+    let required: u32 = env.storage().instance().get(&REQUIRED).unwrap_or(1);
+    signed >= required
+}`,
+    missions: ["multi-party-pact"],
+  },
+  {
+    name: "init pattern",
+    category: "Functions",
+    description:
+      "A convention for initializing contract state. An init function is called once to set up admin addresses or default values before the contract is used.",
+    code: `pub fn init(env: Env, admin: Address) {
+    env.storage().instance().set(&ADMIN, &admin);
+}`,
+    missions: ["guardian-ledger", "token-forge"],
+  },
+  {
+    name: "mint",
+    category: "Functions",
+    description:
+      "A pattern for creating new tokens and assigning them to an address. Typically restricted to an admin using require_auth().",
+    code: `pub fn mint(env: Env, to: Address, amount: i128) {
+    let admin: Address = env.storage().instance().get(&ADMIN).unwrap();
+    admin.require_auth();
+    let balance: i128 = env.storage().persistent().get(&to).unwrap_or(0);
+    env.storage().persistent().set(&to, &(balance + amount));
+}`,
+    missions: ["token-forge"],
+  },
+  {
+    name: "transfer",
+    category: "Functions",
+    description:
+      "A pattern for moving token balances between two addresses. Requires authorization from the sender.",
+    code: `pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+    from.require_auth();
+    let from_bal: i128 = env.storage().persistent().get(&from).unwrap_or(0);
+    let to_bal: i128 = env.storage().persistent().get(&to).unwrap_or(0);
+    env.storage().persistent().set(&from, &(from_bal - amount));
+    env.storage().persistent().set(&to, &(to_bal + amount));
+}`,
+    missions: ["token-forge"],
+  },
+  {
+    name: "time-lock",
+    category: "Functions",
+    description:
+      "A pattern that prevents an action until a specific ledger sequence number is reached. Used to lock funds or actions for a period of time.",
+    code: `pub fn unlock(env: Env, owner: Address) -> i128 {
+    owner.require_auth();
+    let current_seq = env.ledger().sequence();
+    let unlock_at: u32 = env.storage().instance().get(&UNLOCK_AT).unwrap_or(0);
+    if current_seq < unlock_at {
+        panic!("Still locked");
+    }
+    env.storage().instance().get(&LOCKED_AMOUNT).unwrap_or(0)
+}`,
+    missions: ["time-lock"],
+  },
+  {
+    name: "storage().remove()",
+    category: "Storage",
+    description:
+      "Deletes a key from contract storage. Used to clean up state after it is no longer needed, such as after unlocking a time-locked vault.",
+    code: `env.storage().instance().remove(&LOCKED_AMOUNT);
+env.storage().instance().remove(&UNLOCK_AT);`,
+    missions: ["time-lock"],
+  },
+  {
+    name: "multi-sig",
+    category: "Auth",
+    description:
+      "A pattern requiring multiple parties to authorize an action before it executes. Implemented by tracking a signature count against a required threshold.",
+    code: `pub fn sign_pact(env: Env, signer: Address) {
+    signer.require_auth();
+    let count: u32 = env.storage().instance().get(&SIGNED).unwrap_or(0);
+    env.storage().instance().set(&SIGNED, &(count + 1));
+}`,
+    missions: ["multi-party-pact"],
+  },
+  {
+    name: "governance pattern",
+    category: "Functions",
+    description:
+      "A contract design where multiple parties must agree before an action is taken. Combines multi-sig, state tracking, and completion checks.",
+    code: `pub fn is_complete(env: Env) -> bool {
+    let signed: u32 = env.storage().instance().get(&SIGNED).unwrap_or(0);
+    let required: u32 = env.storage().instance().get(&REQUIRED).unwrap_or(1);
+    signed >= required
+}`,
+    missions: ["multi-party-pact"],
+  },
+];
+
+export const categories = [
+  "All",
+  "Attributes",
+  "Types",
+  "Storage",
+  "Auth",
+  "Functions",
+];

--- a/src/index.css
+++ b/src/index.css
@@ -3,8 +3,7 @@
    RPG-inspired dark theme for Stellar/Soroban
    ========================================== */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&family=Orbitron:wght@400;500;600;700;800;900&display=swap');
-
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&family=Orbitron:wght@400;500;600;700;800;900&display=swap");
 
 .notfound-container {
   height: 100vh;
@@ -49,9 +48,15 @@
 }
 
 @keyframes float {
-  0% { transform: translateY(0px); }
-  50% { transform: translateY(-10px); }
-  100% { transform: translateY(0px); }
+  0% {
+    transform: translateY(0px);
+  }
+  50% {
+    transform: translateY(-10px);
+  }
+  100% {
+    transform: translateY(0px);
+  }
 }
 
 /*foot style*/
@@ -138,13 +143,22 @@
   left: -150px;
   height: 100%;
   width: 150px;
-  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.1), transparent);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.1),
+    transparent
+  );
   animation: shimmer 1.2s infinite;
 }
 
 @keyframes shimmer {
-  0% { left: -150px; }
-  100% { left: 100%; }
+  0% {
+    left: -150px;
+  }
+  100% {
+    left: 100%;
+  }
 }
 
 /* Fade-in animation for staggered effect */
@@ -154,7 +168,9 @@
 }
 
 @keyframes fadeIn {
-  to { opacity: 1; }
+  to {
+    opacity: 1;
+  }
 }
 
 /* Responsive container */
@@ -182,7 +198,7 @@
   --bg-tertiary: #1a2236;
   --bg-card: rgba(17, 24, 39, 0.7);
   --bg-glass: rgba(17, 24, 39, 0.5);
-  
+
   /* Accent colors */
   --cyan: #06d6a0;
   --cyan-dim: rgba(6, 214, 160, 0.15);
@@ -199,23 +215,23 @@
   --green-dim: rgba(34, 197, 94, 0.15);
   --blue: #3b82f6;
   --blue-dim: rgba(59, 130, 246, 0.15);
-  
+
   /* Text */
   --text-primary: #f1f5f9;
   --text-secondary: #94a3b8;
   --text-muted: #64748b;
   --text-accent: var(--cyan);
-  
+
   /* Borders */
   --border-subtle: rgba(148, 163, 184, 0.1);
   --border-accent: rgba(6, 214, 160, 0.3);
   --border-glow: rgba(6, 214, 160, 0.6);
-  
+
   /* Typography */
-  --font-body: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-  --font-code: 'JetBrains Mono', 'Fira Code', monospace;
-  --font-display: 'Orbitron', sans-serif;
-  
+  --font-body: "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-code: "JetBrains Mono", "Fira Code", monospace;
+  --font-display: "Orbitron", sans-serif;
+
   /* Spacing */
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
@@ -224,27 +240,29 @@
   --space-xl: 2rem;
   --space-2xl: 3rem;
   --space-3xl: 4rem;
-  
+
   /* Radii */
   --radius-sm: 6px;
   --radius-md: 10px;
   --radius-lg: 16px;
   --radius-xl: 20px;
   --radius-full: 9999px;
-  
+
   /* Shadows */
   --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.3);
   --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.4);
   --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
   --shadow-glow-cyan: 0 0 20px var(--cyan-glow), 0 0 60px rgba(6, 214, 160, 0.1);
-  --shadow-glow-purple: 0 0 20px var(--purple-glow), 0 0 60px rgba(139, 92, 246, 0.1);
-  --shadow-glow-gold: 0 0 20px var(--gold-glow), 0 0 60px rgba(245, 158, 11, 0.1);
-  
+  --shadow-glow-purple: 0 0 20px var(--purple-glow),
+    0 0 60px rgba(139, 92, 246, 0.1);
+  --shadow-glow-gold: 0 0 20px var(--gold-glow),
+    0 0 60px rgba(245, 158, 11, 0.1);
+
   /* Transitions */
   --transition-fast: 150ms ease;
   --transition-base: 250ms ease;
   --transition-slow: 400ms ease;
-  
+
   /* Z-indices */
   --z-navbar: 100;
   --z-modal: 200;
@@ -252,7 +270,9 @@
 }
 
 /* ============ RESET ============ */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
@@ -276,17 +296,28 @@ body {
 
 /* Animated background */
 body::before {
-  content: '';
+  content: "";
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
   z-index: -1;
-  background: 
-    radial-gradient(ellipse at 20% 50%, rgba(6, 214, 160, 0.03) 0%, transparent 50%),
-    radial-gradient(ellipse at 80% 20%, rgba(139, 92, 246, 0.04) 0%, transparent 50%),
-    radial-gradient(ellipse at 50% 80%, rgba(59, 130, 246, 0.03) 0%, transparent 50%),
+  background: radial-gradient(
+      ellipse at 20% 50%,
+      rgba(6, 214, 160, 0.03) 0%,
+      transparent 50%
+    ),
+    radial-gradient(
+      ellipse at 80% 20%,
+      rgba(139, 92, 246, 0.04) 0%,
+      transparent 50%
+    ),
+    radial-gradient(
+      ellipse at 50% 80%,
+      rgba(59, 130, 246, 0.03) 0%,
+      transparent 50%
+    ),
     var(--bg-primary);
   pointer-events: none;
 }
@@ -296,9 +327,14 @@ a {
   text-decoration: none;
   transition: color var(--transition-fast);
 }
-a:hover { color: var(--text-primary); }
+a:hover {
+  color: var(--text-primary);
+}
 
-img { max-width: 100%; display: block; }
+img {
+  max-width: 100%;
+  display: block;
+}
 
 button {
   cursor: pointer;
@@ -376,7 +412,7 @@ button {
 }
 
 .navbar-links a::after {
-  content: '';
+  content: "";
   position: absolute;
   bottom: -2px;
   left: 0;
@@ -549,19 +585,28 @@ button {
 }
 
 .xp-bar-fill::after {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.3) 50%, transparent 100%);
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.3) 50%,
+    transparent 100%
+  );
   animation: xpShimmer 2s infinite;
 }
 
 @keyframes xpShimmer {
-  0% { transform: translateX(-100%); }
-  100% { transform: translateX(100%); }
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
 }
 
 .xp-bar-label {
@@ -635,9 +680,15 @@ button {
   border-radius: 50%;
 }
 
-.terminal-dot.red { background: #ff5f56; }
-.terminal-dot.yellow { background: #ffbd2e; }
-.terminal-dot.green { background: #27c93f; }
+.terminal-dot.red {
+  background: #ff5f56;
+}
+.terminal-dot.yellow {
+  background: #ffbd2e;
+}
+.terminal-dot.green {
+  background: #27c93f;
+}
 
 .terminal-title {
   color: var(--text-muted);
@@ -675,8 +726,14 @@ button {
 }
 
 @keyframes terminalFadeIn {
-  from { opacity: 0; transform: translateY(4px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* ============ MISSION CARD ============ */
@@ -692,7 +749,7 @@ button {
 }
 
 .mission-card::before {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: 0;
@@ -853,7 +910,12 @@ button {
 }
 
 .hero-title-gradient {
-  background: linear-gradient(135deg, var(--cyan) 0%, var(--purple) 50%, var(--gold) 100%);
+  background: linear-gradient(
+    135deg,
+    var(--cyan) 0%,
+    var(--purple) 50%,
+    var(--gold) 100%
+  );
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -901,8 +963,14 @@ button {
 }
 
 @keyframes fadeSlideUp {
-  from { opacity: 0; transform: translateY(20px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* ============ FEATURES SECTION ============ */
@@ -1337,13 +1405,23 @@ button {
 }
 
 @keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes scaleIn {
-  from { opacity: 0; transform: scale(0.8); }
-  to { opacity: 1; transform: scale(1); }
+  from {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 /* ============ SCROLLBAR ============ */
@@ -1375,7 +1453,9 @@ button {
 }
 
 @keyframes spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* ============ RESPONSIVE ============ */
@@ -1384,13 +1464,13 @@ button {
     grid-template-columns: 1fr;
     grid-template-rows: auto 1fr auto;
   }
-  
+
   .mission-story {
     max-height: 300px;
     border-right: none;
     border-bottom: 1px solid var(--border-subtle);
   }
-  
+
   .navbar-links {
     display: none;
   }
@@ -1405,16 +1485,16 @@ button {
   .hero-title {
     font-size: 2rem;
   }
-  
+
   .hero-actions {
     flex-direction: column;
   }
-  
+
   .profile-header {
     flex-direction: column;
     text-align: center;
   }
-  
+
   .mission-map-grid {
     grid-template-columns: 1fr;
   }
@@ -1422,7 +1502,6 @@ button {
 
 /* MOBILE STYLES  (768px and below) */
 @media (max-width: 768px) {
-
   /* Show the tab bar */
   .mobile-tabs {
     display: flex;
@@ -1465,15 +1544,15 @@ button {
   }
 
   /* Active tab indicator — driven entirely by :checked, no JS */
-  #tab-story:checked  ~ .mobile-tabs label[for="tab-story"],
+  #tab-story:checked ~ .mobile-tabs label[for="tab-story"],
   #tab-editor:checked ~ .mobile-tabs label[for="tab-editor"],
-  #tab-tests:checked  ~ .mobile-tabs label[for="tab-tests"] {
+  #tab-tests:checked ~ .mobile-tabs label[for="tab-tests"] {
     color: var(--cyan);
   }
 
-  #tab-story:checked  ~ .mobile-tabs label[for="tab-story"]::after,
+  #tab-story:checked ~ .mobile-tabs label[for="tab-story"]::after,
   #tab-editor:checked ~ .mobile-tabs label[for="tab-editor"]::after,
-  #tab-tests:checked  ~ .mobile-tabs label[for="tab-tests"]::after {
+  #tab-tests:checked ~ .mobile-tabs label[for="tab-tests"]::after {
     width: 100%;
   }
 
@@ -1560,3 +1639,199 @@ button {
     min-height: 44px;
   }
 }
+/* GLOSSARY PAGE */
+.glossary-page {
+  padding: var(--space-2xl) var(--space-xl);
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.glossary-header {
+  text-align: center;
+  margin-bottom: var(--space-2xl);
+}
+
+.glossary-title-gradient {
+  background: linear-gradient(135deg, var(--cyan), var(--purple));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.glossary-search {
+  width: 100%;
+  max-width: 500px;
+  padding: 0.75rem 1.25rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-full);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  outline: none;
+  transition: border-color var(--transition-base),
+    box-shadow var(--transition-base);
+  margin-bottom: var(--space-lg);
+}
+
+.glossary-search:focus {
+  border-color: var(--cyan);
+  box-shadow: 0 0 0 3px var(--cyan-dim);
+}
+
+.glossary-search::placeholder {
+  color: var(--text-muted);
+}
+
+.glossary-filters {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-xl);
+}
+
+.glossary-filter-chip {
+  padding: 0.4rem 1rem;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-weight: 500;
+  transition: all var(--transition-fast);
+}
+
+.glossary-filter-chip:hover {
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+
+.glossary-filter-chip.active {
+  background: var(--cyan-dim);
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+
+.glossary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: var(--space-lg);
+}
+
+.glossary-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg);
+  backdrop-filter: blur(10px);
+  transition: all var(--transition-base);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.glossary-card:hover {
+  border-color: var(--border-accent);
+  box-shadow: var(--shadow-glow-cyan);
+  transform: translateY(-2px);
+}
+
+.glossary-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.glossary-card-name {
+  font-family: var(--font-code);
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--cyan);
+}
+
+.glossary-category-tag {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 2px 10px;
+  border-radius: var(--radius-full);
+}
+
+.glossary-category-attributes {
+  background: var(--purple-dim);
+  color: var(--purple);
+  border: 1px solid rgba(139, 92, 246, 0.2);
+}
+.glossary-category-types {
+  background: var(--cyan-dim);
+  color: var(--cyan);
+  border: 1px solid rgba(6, 214, 160, 0.2);
+}
+.glossary-category-storage {
+  background: var(--gold-dim);
+  color: var(--gold);
+  border: 1px solid rgba(245, 158, 11, 0.2);
+}
+.glossary-category-auth {
+  background: var(--red-dim);
+  color: var(--red);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+}
+.glossary-category-functions {
+  background: var(--blue-dim);
+  color: var(--blue);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+}
+
+.glossary-card-desc {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.glossary-code {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  overflow-x: auto;
+  font-family: var(--font-code);
+  font-size: 0.8rem;
+  color: var(--text-primary);
+  line-height: 1.6;
+}
+
+.glossary-card-missions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  margin-top: var(--space-xs);
+}
+
+.glossary-empty {
+  text-align: center;
+  color: var(--text-muted);
+  padding: var(--space-3xl);
+  font-size: 1rem;
+}
+
+@media (max-width: 600px) {
+  .glossary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .glossary-search {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 375px) {
+  .glossary-page {
+    padding: var(--space-lg) var(--space-md);
+  }
+}
+/* End of Glossary Page style*/

--- a/src/pages/Glossary.jsx
+++ b/src/pages/Glossary.jsx
@@ -1,0 +1,95 @@
+import React, { useState, useMemo, useEffect } from "react";
+import { glossaryTerms, categories } from "../data/glossary";
+
+function useDebounce(value, delay = 300) {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+  return debounced;
+}
+
+export default function Glossary() {
+  const [search, setSearch] = useState("");
+  const [activeCategory, setActiveCategory] = useState("All");
+  const debouncedSearch = useDebounce(search);
+
+  const filtered = useMemo(() => {
+    const q = debouncedSearch.toLowerCase();
+    return glossaryTerms.filter((term) => {
+      const matchesCategory =
+        activeCategory === "All" || term.category === activeCategory;
+      const matchesSearch =
+        term.name.toLowerCase().includes(q) ||
+        term.description.toLowerCase().includes(q);
+      return matchesCategory && matchesSearch;
+    });
+  }, [debouncedSearch, activeCategory]);
+
+  return (
+    <div className="glossary-page">
+      <div className="glossary-header">
+        <h1 className="section-title">
+          📖 <span className="glossary-title-gradient">Soroban Glossary</span>
+        </h1>
+        <p className="section-subtitle">
+          A central reference for all Soroban SDK concepts introduced across
+          missions.
+        </p>
+
+        <input
+          className="glossary-search"
+          type="text"
+          placeholder="Search concepts..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+
+        <div className="glossary-filters">
+          {categories.map((cat) => (
+            <button
+              key={cat}
+              className={`glossary-filter-chip ${
+                activeCategory === cat ? "active" : ""
+              }`}
+              onClick={() => setActiveCategory(cat)}
+            >
+              {cat}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className="glossary-empty">No concepts match your search.</p>
+      ) : (
+        <div className="glossary-grid">
+          {filtered.map((term) => (
+            <div key={term.name} className="glossary-card">
+              <div className="glossary-card-header">
+                <span className="glossary-card-name">{term.name}</span>
+                <span
+                  className={`glossary-category-tag glossary-category-${term.category.toLowerCase()}`}
+                >
+                  {term.category}
+                </span>
+              </div>
+              <p className="glossary-card-desc">{term.description}</p>
+              <pre className="glossary-code">
+                <code>{term.code}</code>
+              </pre>
+              <div className="glossary-card-missions">
+                {term.missions.map((m) => (
+                  <span key={m} className="concept-tag">
+                    {m}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #35

---

Adds a searchable Soroban Glossary page that serves as a central reference for all SDK concepts introduced across missions. Previously there was no single place to revisit concepts like #[contract], require_auth(), or storage operations after completing a mission.

Changes made:

src/data/glossary.js — new data file with 28 concept definitions covering all 7 missions, each with name, category, description, code example, and which missions introduce it. Extracted from the existing conceptsIntroduced field in missions.js

src/pages/Glossary.jsx — new page with a debounced search input, category filter chips (Attributes, Types, Storage, Auth, Functions), and concept cards

src/App.jsx — added /glossary route

src/components/Navbar.jsx — added Glossary link with active state support

src/index.css — added all glossary styles using existing CSS variables and design system
![Glossary-page](https://github.com/user-attachments/assets/a36a21c6-81d2-4da9-a579-5444ffdc5344)
