### PR TITLE
feat: add Monaco diff viewer for comparing user code with solution

### DIFF
--- a/src/components/DiffViewer.jsx
+++ b/src/components/DiffViewer.jsx
@@ -1,0 +1,151 @@
+// src/components/DiffViewer.jsx
+import React, { useRef, useEffect, useState } from "react";
+
+export default function DiffViewer({ userCode, solutionCode, onClose }) {
+  const containerRef = useRef(null);
+  const diffEditorRef = useRef(null);
+  const [inline, setInline] = useState(false);
+  const [monacoReady, setMonacoReady] = useState(false);
+
+  // Boot the diff editor once Monaco is available on window
+  useEffect(() => {
+    let cancelled = false;
+
+    function tryInit() {
+      if (cancelled) return;
+      if (!containerRef.current) return;
+
+      // Monaco is loaded by @monaco-editor/react — wait for it
+      if (!window.monaco) {
+        setTimeout(tryInit, 100);
+        return;
+      }
+
+      const editor = window.monaco.editor.createDiffEditor(containerRef.current, {
+        theme: "vs-dark",
+        fontSize: 14,
+        fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+        minimap: { enabled: false },
+        scrollBeyondLastLine: false,
+        automaticLayout: true,
+        renderSideBySide: true,   // overridden by toggle below
+        readOnly: true,
+        padding: { top: 16 },
+        wordWrap: "on",
+        lineNumbers: "on",
+        renderLineHighlight: "all",
+        diffWordWrap: "on",
+      });
+
+      const original = window.monaco.editor.createModel(userCode, "rust");
+      const modified = window.monaco.editor.createModel(solutionCode, "rust");
+      editor.setModel({ original, modified });
+
+      diffEditorRef.current = editor;
+      setMonacoReady(true);
+    }
+
+    tryInit();
+
+    return () => {
+      cancelled = true;
+      if (diffEditorRef.current) {
+        diffEditorRef.current.dispose();
+        diffEditorRef.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Toggle inline / side-by-side without recreating the editor
+  useEffect(() => {
+    if (!diffEditorRef.current) return;
+    diffEditorRef.current.updateOptions({ renderSideBySide: !inline });
+  }, [inline]);
+
+  // Trap Escape key
+  useEffect(() => {
+    const handler = (e) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  return (
+    <div className="diff-overlay" onClick={onClose}>
+      <div className="diff-modal" onClick={(e) => e.stopPropagation()}>
+
+        {/* ── Header ── */}
+        <div className="diff-header">
+          <div className="diff-header-left">
+            <span className="diff-icon">⚡</span>
+            <span className="diff-title">Code Comparison</span>
+          </div>
+
+          <div className="diff-header-center">
+            <div className="diff-labels">
+              <span className="diff-label your-code">● Your Code</span>
+              <span className="diff-label solution">● Reference Solution</span>
+            </div>
+          </div>
+
+          <div className="diff-header-right">
+            {/* Inline / Side-by-side toggle */}
+            <div className="diff-toggle" title="Switch view mode">
+              <button
+                className={`diff-toggle-btn ${!inline ? "active" : ""}`}
+                onClick={() => setInline(false)}
+              >
+                ⧉ Side-by-side
+              </button>
+              <button
+                className={`diff-toggle-btn ${inline ? "active" : ""}`}
+                onClick={() => setInline(true)}
+              >
+                ≡ Inline
+              </button>
+            </div>
+
+            <button className="btn btn-secondary btn-sm" onClick={onClose}>
+              ← Back to Editor
+            </button>
+          </div>
+        </div>
+
+        {/* ── Column headers ── */}
+        {!inline && (
+          <div className="diff-col-headers">
+            <div className="diff-col-header your-code">📝 Your Code</div>
+            <div className="diff-col-header solution">✅ Reference Solution</div>
+          </div>
+        )}
+        {inline && (
+          <div className="diff-col-headers inline-header">
+            <div className="diff-col-header">≡ Inline Diff — red = removed · green = added</div>
+          </div>
+        )}
+
+        {/* ── Monaco diff editor container ── */}
+        <div className="diff-editor-wrapper">
+          {!monacoReady && (
+            <div className="diff-loading">
+              <span className="spinner" style={{ width: 24, height: 24 }} />
+              <span>Loading diff engine…</span>
+            </div>
+          )}
+          <div
+            ref={containerRef}
+            style={{ width: "100%", height: "100%", opacity: monacoReady ? 1 : 0 }}
+          />
+        </div>
+
+        {/* ── Legend ── */}
+        <div className="diff-legend">
+          <span className="diff-legend-item added">＋ Lines you need to add</span>
+          <span className="diff-legend-item removed">－ Lines that differ from solution</span>
+          <span className="diff-legend-item unchanged">　 Unchanged lines</span>
+          <span className="diff-legend-hint">Press Esc to close</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1560,3 +1560,259 @@ button {
     min-height: 44px;
   }
 }
+
+/* ============================================================
+             DIFF VIEWER
+   ============================================================ */
+
+/* ── Full-screen overlay ── */
+.diff-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.82);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  z-index: calc(var(--z-modal) + 10);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: fadeIn 0.2s ease;
+}
+
+/* ── Modal card ── */
+.diff-modal {
+  width: min(98vw, 1300px);
+  height: min(92vh, 900px);
+  background: #0d1117;
+  border: 1px solid var(--border-accent);
+  border-radius: var(--radius-xl);
+  box-shadow: 0 0 60px rgba(6, 214, 160, 0.15), var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: scaleIn 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* ── Header bar ── */
+.diff-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-subtle);
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+.diff-header-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.diff-icon {
+  font-size: 1rem;
+}
+
+.diff-title {
+  font-family: var(--font-display);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 1px;
+  color: var(--cyan);
+  text-transform: uppercase;
+}
+
+.diff-header-center {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.diff-labels {
+  display: flex;
+  gap: 20px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  font-family: var(--font-code);
+}
+
+.diff-label.your-code  { color: #60a5fa; }   /* blue  */
+.diff-label.solution   { color: var(--cyan); } /* green */
+
+.diff-header-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+/* ── Inline / Side-by-side toggle ── */
+.diff-toggle {
+  display: flex;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.diff-toggle-btn {
+  padding: 5px 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  font-family: var(--font-body);
+}
+
+.diff-toggle-btn:hover {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.diff-toggle-btn.active {
+  color: var(--cyan);
+  background: var(--cyan-dim);
+}
+
+/* ── Column labels row ── */
+.diff-col-headers {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  background: #0a0e1a;
+  border-bottom: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+}
+
+.diff-col-headers.inline-header {
+  grid-template-columns: 1fr;
+}
+
+.diff-col-header {
+  padding: 6px 20px;
+  font-family: var(--font-code);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--text-muted);
+}
+
+.diff-col-header.your-code {
+  color: #60a5fa;
+  border-right: 1px solid var(--border-subtle);
+}
+
+.diff-col-header.solution {
+  color: var(--cyan);
+  padding-left: 24px;
+}
+
+/* ── Monaco container ── */
+.diff-editor-wrapper {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}
+
+/* ── Loading state ── */
+.diff-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  background: #0d1117;
+}
+
+/* ── Legend footer ── */
+.diff-legend {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 7px 18px;
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border-subtle);
+  font-family: var(--font-code);
+  font-size: 0.72rem;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.diff-legend-item       { color: var(--text-muted); }
+.diff-legend-item.added   { color: #4ade80; }
+.diff-legend-item.removed { color: #f87171; }
+.diff-legend-item.unchanged { color: var(--text-muted); }
+
+.diff-legend-hint {
+  margin-left: auto;
+  color: var(--text-muted);
+  opacity: 0.6;
+  font-size: 0.68rem;
+}
+
+/* ── "Compare" button in the toolbar ── */
+.diff-compare-btn {
+  color: var(--cyan) !important;
+  border: 1px solid rgba(6, 214, 160, 0.25) !important;
+  background: var(--cyan-dim) !important;
+}
+
+.diff-compare-btn:hover {
+  background: rgba(6, 214, 160, 0.2) !important;
+  border-color: var(--cyan) !important;
+}
+
+/* ── Clickable hint inside terminal header ── */
+.terminal-compare-hint {
+  margin-left: auto;
+  font-size: 0.72rem;
+  color: var(--cyan);
+  cursor: pointer;
+  opacity: 0.75;
+  transition: opacity var(--transition-fast);
+  font-family: var(--font-code);
+  user-select: none;
+}
+
+.terminal-compare-hint:hover {
+  opacity: 1;
+}
+
+/* ── Mobile: full-screen diff modal ── */
+@media (max-width: 768px) {
+  .diff-modal {
+    width: 100vw;
+    height: 100vh;
+    border-radius: 0;
+    border: none;
+  }
+
+  .diff-header {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .diff-header-center {
+    order: 3;
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .diff-col-headers {
+    display: none; /* too narrow for two column labels on mobile */
+  }
+
+  .diff-legend-hint {
+    display: none;
+  }
+}

--- a/src/pages/MissionDetail.jsx
+++ b/src/pages/MissionDetail.jsx
@@ -13,6 +13,7 @@ import {
 } from "../systems/gameEngine";
 import MissionDetailSkeleton from "../components/MissionDetailSkeleton";
 import { useokashi, TOAST_STATES } from "../systems/useokashi";
+import DiffViewer from "../components/DiffViewer";   
 
 export default function MissionDetail() {
   const { missionId } = useParams();
@@ -27,6 +28,8 @@ export default function MissionDetail() {
   const [showVictory, setShowVictory] = useState(false);
   const [victoryData, setVictoryData] = useState(null);
   const [hintIndex, setHintIndex] = useState(-1);
+  const [hasAttempted, setHasAttempted] = useState(false);
+  const [showDiff, setShowDiff] = useState(false);
 
   const terminalBodyRef = useRef(null);
   const { openInOkashi, toast } = useokashi();
@@ -41,6 +44,8 @@ export default function MissionDetail() {
         setTestResults([]);
         setHintIndex(-1);
         setShowVictory(false);
+        setHasAttempted(false);
+        setShowDiff(false);  
         setLoading(false);
       }, 1500);
     } else {
@@ -60,6 +65,7 @@ export default function MissionDetail() {
     if (isRunning || !mission) return;
     setIsRunning(true);
     setTestResults([]);
+    setHasAttempted(true);  
 
     // Record user attempt
     let state = loadProgress();
@@ -266,6 +272,16 @@ export default function MissionDetail() {
               >
                 👁️ Solution
               </button>
+             {hasAttempted && mission?.solution && (
+                <button
+                  className="btn btn-ghost btn-sm diff-compare-btn"
+                  onClick={() => setShowDiff(true)}
+                  title="Compare your code with the reference solution"
+                >
+                  ⧉ Compare
+                </button>
+              )}
+ 
               <button
                 className="btn btn-primary btn-sm"
                 onClick={handleRunTests}
@@ -273,10 +289,7 @@ export default function MissionDetail() {
               >
                 {isRunning ? (
                   <>
-                    <span
-                      className="spinner"
-                      style={{ width: 14, height: 14 }}
-                    />{" "}
+                    <span className="spinner" style={{ width: 14, height: 14 }} />{" "}
                     Running...
                   </>
                 ) : (
@@ -285,7 +298,7 @@ export default function MissionDetail() {
               </button>
             </div>
           </div>
-
+ 
           <div className="editor-wrapper">
             <Editor
               height="100%"
@@ -325,6 +338,16 @@ export default function MissionDetail() {
                 <span className="terminal-dot yellow" />
                 <span className="terminal-dot green" />
                 <span className="terminal-title">Test Output</span>
+             {/* ── Hint after failed attempt ── */}
+                {hasAttempted && !isRunning && testResults.length > 0 && (
+                  <span
+                    className="terminal-compare-hint"
+                    onClick={() => setShowDiff(true)}
+                    title="Open diff viewer"
+                  >
+                    ⧉ Compare with solution
+                  </span>
+                )}
               </div>
               <div
                 className="terminal-body"
@@ -354,7 +377,16 @@ export default function MissionDetail() {
           </div>
         </div>
       </div>
-
+ 
+      {/* ── Diff Viewer Overlay ── */}
+      {showDiff && (
+        <DiffViewer
+          userCode={code}
+          solutionCode={mission.solution}
+          onClose={() => setShowDiff(false)}
+        />
+      )}
+ 
       {/* ---------------- Victory Modal ---------------- */}
       {showVictory && victoryData && (
         <div className="modal-overlay" onClick={() => setShowVictory(false)}>
@@ -365,7 +397,7 @@ export default function MissionDetail() {
               You've completed <strong>{mission.title}</strong>
             </p>
             <div className="modal-xp">+{victoryData.xp} XP</div>
-
+ 
             {victoryData.leveledUp && (
               <p
                 style={{
@@ -378,21 +410,14 @@ export default function MissionDetail() {
                 {getRankTitle(victoryData.newLevel)}
               </p>
             )}
-
+ 
             {victoryData.newBadges?.length > 0 && (
               <p style={{ color: "var(--gold)", marginBottom: "1rem" }}>
-                🏅 New badge{victoryData.newBadges.length > 1 ? "s" : ""}{" "}
-                earned!
+                🏅 New badge{victoryData.newBadges.length > 1 ? "s" : ""} earned!
               </p>
             )}
-
-            <div
-              style={{
-                display: "flex",
-                gap: "0.75rem",
-                justifyContent: "center",
-              }}
-            >
+ 
+            <div style={{ display: "flex", gap: "0.75rem", justifyContent: "center" }}>
               <button className="btn btn-primary" onClick={handleNextMission}>
                 Next Mission →
               </button>


### PR DESCRIPTION
### Add Monaco Diff Viewer for Code Comparison

Closes #42 

## Summary
Implement a side-by-side diff viewer using Monaco's diff editor API to compare user code with the reference solution.

## Changes

- Created `DiffViewer.jsx` component with Monaco diff editor
- Added "⧉ Compare" button in MissionDetail toolbar (appears after first test attempt)
- Implemented toggle between inline and side-by-side diff modes
- Added styling consistent with dark RPG theme
- Added Escape key support and terminal hint link

## Acceptance Criteria

- [x] "Compare with Solution" button appears after first test attempt
- [x] Clicking opens Monaco diff editor showing user code vs. reference
- [x] Differences highlighted with green (additions) and red (deletions)
- [x] Toggle between inline and side-by-side modes works
- [x] "Back to Editor" returns to normal view with code preserved
- [x] Styled consistently with dark theme

## Testing

Tested locally with `npm run dev` — all features working as expected.


---

**Ready for review**
