### PR TITLE
feat: add Chapter 0 Rust fundamentals onboarding missions

### DIFF
--- a/src/data/missions.js
+++ b/src/data/missions.js
@@ -1,8 +1,365 @@
 /* ==========================================
-   Mission Data — 7 progressive Soroban missions
+   Mission Data — Rust fundamentals + Soroban missions
    ========================================== */
 
 export const missions = [
+    {
+        id: 'rust-variables-and-types',
+        title: 'Rust Orientation',
+        chapter: 0,
+        order: 1,
+        difficulty: 'beginner',
+        xpReward: 50,
+        story: `# 🧭 The Rust Outpost
+
+Before the Stellar Citadel allows you near Soroban, you are escorted to an orbital academy known as the **Rust Outpost**.
+
+*"Every guardian starts here,"* says the quartermaster. *"Learn how Rust stores values, and the language will stop feeling alien."*
+
+## Your Mission
+
+Create a small function that introduces four foundational Rust types:
+
+- \`i32\` for signed numbers
+- \`u64\` for large positive counters
+- \`String\` for owned text
+- \`bool\` for true or false decisions
+
+You will also practice \`let\` bindings and \`mut\` variables.
+
+## What You'll Learn
+
+- Immutable vs mutable bindings
+- Common primitive types
+- Returning multiple values as a tuple
+- Building strings with \`.to_string()\`
+
+Complete the template and prepare your first Rust report.`,
+        learningGoal: 'Use let, mut, and basic Rust types in a single function',
+        template: `fn build_status_report() -> (i32, u64, String, bool) {
+    // TODO: Create a mutable i32 named level starting at 1
+    // TODO: Increase level by 1
+    // TODO: Create a u64 named energy with the value 900
+    // TODO: Create a String named codename with "Nova"
+    // TODO: Create a bool named ready with true
+    // TODO: Return all four values as a tuple
+}`,
+        solution: `fn build_status_report() -> (i32, u64, String, bool) {
+    let mut level: i32 = 1;
+    level += 1;
+    let energy: u64 = 900;
+    let codename: String = "Nova".to_string();
+    let ready: bool = true;
+
+    (level, energy, codename, ready)
+}`,
+        checks: [
+            { type: 'has_function', name: 'build_status_report', message: "Missing 'build_status_report' function" },
+            { type: 'returns_type', function: 'build_status_report', returnType: '(i32, u64, String, bool)', message: "'build_status_report' should return (i32, u64, String, bool)" },
+            { type: 'contains_pattern', pattern: 'let mut level: i32 = 1;', message: 'Create a mutable i32 named level', description: 'mutable i32 binding' },
+            { type: 'contains_pattern', pattern: 'let energy: u64 = 900;', message: 'Create a u64 named energy', description: 'u64 binding' },
+            { type: 'contains_pattern', pattern: '.to_string()', message: 'Create the String value with .to_string()', description: 'String creation' },
+            { type: 'contains_pattern', pattern: 'let ready: bool = true;', message: 'Create a bool named ready', description: 'bool binding' },
+            { type: 'no_pattern', pattern: 'soroban_sdk', message: 'Chapter 0 missions should use pure Rust only', description: 'Soroban SDK imports' },
+        ],
+        hints: [
+            'Start with `let mut level: i32 = 1;` and then increment it.',
+            'Owned text should use `String`, for example `"Nova".to_string()`.',
+            'Return the values in the same order as the tuple type: `(level, energy, codename, ready)`.',
+        ],
+        conceptsIntroduced: ['let', 'mut', 'i32', 'u64', 'String', 'bool'],
+    },
+
+    {
+        id: 'rust-functions-and-returns',
+        title: 'Signal Calculations',
+        chapter: 0,
+        order: 2,
+        difficulty: 'beginner',
+        xpReward: 75,
+        story: `# 📶 The Relay Deck
+
+The academy guides you into the **Relay Deck**, where every signal must be transformed with precision.
+
+*"Rust rewards explicit intent,"* the instructor says. *"Functions are promises. Their parameters and return types tell other engineers what they can trust."*
+
+## Your Mission
+
+Write two small functions:
+
+- \`amplify_signal\` multiplies two numbers
+- \`mission_status\` returns a text label based on a boolean input
+
+## What You'll Learn
+
+- Function signatures with parameters
+- Return type annotations using \`->\`
+- Returning expressions directly
+- Simple branching with \`if\`
+
+Complete both functions so the relay system can classify incoming signals.`,
+        learningGoal: 'Define functions with parameters and explicit return types',
+        template: `fn amplify_signal(base: i32, multiplier: i32) -> i32 {
+    // TODO: Return the multiplied value
+}
+
+fn mission_status(completed: bool) -> &'static str {
+    // TODO: Return "complete" when completed is true
+    // TODO: Otherwise return "pending"
+}`,
+        solution: `fn amplify_signal(base: i32, multiplier: i32) -> i32 {
+    base * multiplier
+}
+
+fn mission_status(completed: bool) -> &'static str {
+    if completed {
+        "complete"
+    } else {
+        "pending"
+    }
+}`,
+        checks: [
+            { type: 'has_function', name: 'amplify_signal', params: ['base: i32', 'multiplier: i32'], message: "Missing 'amplify_signal(base: i32, multiplier: i32)'" },
+            { type: 'returns_type', function: 'amplify_signal', returnType: 'i32', message: "'amplify_signal' should return i32" },
+            { type: 'contains_pattern', pattern: 'base * multiplier', message: 'Multiply the two parameters', description: 'multiplication expression' },
+            { type: 'has_function', name: 'mission_status', params: ['completed: bool'], message: "Missing 'mission_status(completed: bool)'" },
+            { type: 'returns_type', function: 'mission_status', returnType: "&'static str", message: "'mission_status' should return &'static str" },
+            { type: 'contains_pattern', pattern: 'if completed', message: 'Use an if expression to branch on completed', description: 'if expression' },
+            { type: 'no_pattern', pattern: 'soroban_sdk', message: 'Chapter 0 missions should use pure Rust only', description: 'Soroban SDK imports' },
+        ],
+        hints: [
+            'A Rust function can return the last expression without `return` or a semicolon.',
+            'The status function should use `if completed { ... } else { ... }`.',
+            'Use string literals for the labels: `"complete"` and `"pending"`.',
+        ],
+        conceptsIntroduced: ['fn', 'parameters', 'return types', '-> syntax', 'if expressions'],
+    },
+
+    {
+        id: 'rust-structs-and-enums',
+        title: 'Guardian Records',
+        chapter: 0,
+        order: 3,
+        difficulty: 'intermediate',
+        xpReward: 100,
+        story: `# 📚 The Archive Hall
+
+Rows of glowing tablets fill the **Archive Hall**. Each one describes a guardian, a role, and the state of an active assignment.
+
+*"Rust does not just store values,"* says the archivist. *"It lets you model the world directly."*
+
+## Your Mission
+
+Define:
+
+- A \`Guardian\` struct with a name and rank
+- A \`MissionState\` enum with three variants
+- An \`impl\` block with methods that update and inspect a guardian
+
+## What You'll Learn
+
+- Struct fields
+- Enum variants
+- \`impl\` blocks and methods
+- Borrowing with \`&self\` and mutation with \`&mut self\`
+
+Build the archive entries so the academy can track who is ready for duty.`,
+        learningGoal: 'Model Rust data with structs, enums, and methods',
+        template: `struct Guardian {
+    // TODO: Add \`name: String\` and \`rank: u32\`
+}
+
+enum MissionState {
+    // TODO: Add Locked, InProgress, and Complete
+}
+
+impl Guardian {
+    // TODO: Add a method named promote that increases rank by 1
+
+    // TODO: Add a method named can_accept
+    // It should take &self and state: MissionState
+    // It should return bool
+}`,
+        solution: `struct Guardian {
+    name: String,
+    rank: u32,
+}
+
+enum MissionState {
+    Locked,
+    InProgress,
+    Complete,
+}
+
+impl Guardian {
+    fn promote(&mut self) {
+        self.rank += 1;
+    }
+
+    fn can_accept(&self, state: MissionState) -> bool {
+        match state {
+            MissionState::Locked => false,
+            MissionState::InProgress | MissionState::Complete => self.rank > 0,
+        }
+    }
+}`,
+        checks: [
+            { type: 'has_struct', name: 'Guardian', message: "Missing 'Guardian' struct" },
+            { type: 'uses_type', typeName: 'String', message: 'Guardian should use a String field for the name' },
+            { type: 'contains_pattern', pattern: 'enum MissionState', message: "Missing 'MissionState' enum", description: 'MissionState enum' },
+            { type: 'contains_pattern', pattern: 'impl Guardian', message: "Missing 'impl Guardian' block", description: 'Guardian impl block' },
+            { type: 'has_function', name: 'promote', params: ['&mut self'], message: "Missing 'promote(&mut self)' method" },
+            { type: 'has_function', name: 'can_accept', params: ['&self', 'state: MissionState'], message: "Missing 'can_accept(&self, state: MissionState)' method" },
+            { type: 'returns_type', function: 'can_accept', returnType: 'bool', message: "'can_accept' should return bool" },
+            { type: 'no_pattern', pattern: 'soroban_sdk', message: 'Chapter 0 missions should use pure Rust only', description: 'Soroban SDK imports' },
+        ],
+        hints: [
+            'A struct field looks like `name: String,` inside the braces.',
+            'Methods inside `impl Guardian` should use `self.rank` to access the field.',
+            'You can return a bool from `match state { ... }` directly.',
+        ],
+        conceptsIntroduced: ['struct', 'enum', 'impl', 'methods', '&self', '&mut self'],
+    },
+
+    {
+        id: 'rust-pattern-matching',
+        title: 'Pattern Signals',
+        chapter: 0,
+        order: 4,
+        difficulty: 'intermediate',
+        xpReward: 100,
+        story: `# 🎯 The Signal Chamber
+
+Inside the **Signal Chamber**, messages arrive in uncertain forms: some are present, some are missing, and some carry errors.
+
+*"A strong Rust engineer does not guess,"* the tactician says. *"They match every possibility and handle each one clearly."*
+
+## Your Mission
+
+Work with both \`Option<T>\` and \`Result<T, E>\`:
+
+- Use \`match\` to inspect an optional supply value
+- Use \`if let\` to read a successful signal message
+
+## What You'll Learn
+
+- \`match\` expressions
+- \`if let\` for focused pattern handling
+- \`Option<T>\` and \`Result<T, E>\`
+- Avoiding unsafe shortcuts like \`unwrap()\`
+
+Decode the chamber's transmissions without losing control flow clarity.`,
+        learningGoal: 'Use match and if let with Option and Result values',
+        template: `fn inspect_supply(slot: Option<i32>) -> i32 {
+    // TODO: Use match to return the inner value
+    // TODO: Return 0 when the slot is None
+}
+
+fn read_signal(signal: Result<&'static str, &'static str>) -> &'static str {
+    // TODO: Use if let to return the Ok message
+    // TODO: Otherwise return "retry"
+}`,
+        solution: `fn inspect_supply(slot: Option<i32>) -> i32 {
+    match slot {
+        Some(value) => value,
+        None => 0,
+    }
+}
+
+fn read_signal(signal: Result<&'static str, &'static str>) -> &'static str {
+    if let Ok(message) = signal {
+        message
+    } else {
+        "retry"
+    }
+}`,
+        checks: [
+            { type: 'has_function', name: 'inspect_supply', params: ['slot: Option<i32>'], message: "Missing 'inspect_supply(slot: Option<i32>)'" },
+            { type: 'returns_type', function: 'inspect_supply', returnType: 'i32', message: "'inspect_supply' should return i32" },
+            { type: 'contains_pattern', pattern: 'match slot', message: 'Use match with the Option input', description: 'match expression' },
+            { type: 'has_function', name: 'read_signal', params: ["signal: Result<&'static str, &'static str>"], message: "Missing 'read_signal(signal: Result<&'static str, &'static str>)'" },
+            { type: 'returns_type', function: 'read_signal', returnType: "&'static str", message: "'read_signal' should return &'static str" },
+            { type: 'contains_pattern', pattern: 'if let Ok(message) = signal', message: 'Use if let to handle the Ok case', description: 'if let Ok(...)' },
+            { type: 'no_pattern', pattern: 'unwrap()', message: 'Do not use unwrap() in this pattern matching mission', description: 'unwrap()' },
+        ],
+        hints: [
+            'For `Option<i32>`, the match arms should cover `Some(value)` and `None`.',
+            'An `if let Ok(message) = signal` pattern extracts the success value.',
+            'Return `"retry"` in the fallback branch instead of calling `unwrap()`.',
+        ],
+        conceptsIntroduced: ['match', 'if let', 'Option<T>', 'Result<T, E>', 'control flow'],
+    },
+
+    {
+        id: 'rust-error-handling',
+        title: 'Safe Routes',
+        chapter: 0,
+        order: 5,
+        difficulty: 'intermediate',
+        xpReward: 125,
+        story: `# 🚨 The Recovery Beacon
+
+The last lesson takes place beside the **Recovery Beacon**, where failed expeditions are analyzed before anyone enters Soroban territory.
+
+*"Real systems fail,"* the beacon engineer says. *"Rust teaches you to surface those failures honestly and recover when it makes sense."*
+
+## Your Mission
+
+Create a custom error type and write two helper functions:
+
+- \`first_stop\` should use \`Result\` plus the \`?\` operator
+- \`display_name\` should recover from a missing value with \`unwrap_or\`
+
+## What You'll Learn
+
+- Custom error enums
+- Propagating errors with \`?\`
+- Converting \`Option\` into \`Result\`
+- When \`unwrap\` is tempting and when \`unwrap_or\` is safer
+
+Build a safer route system before the real blockchain journey begins.`,
+        learningGoal: 'Handle errors with Result, ?, unwrap_or, and custom errors',
+        template: `enum NavigationError {
+    // TODO: Add EmptyRoute
+}
+
+fn first_stop(route: Result<Vec<&'static str>, NavigationError>) -> Result<&'static str, NavigationError> {
+    // TODO: Use ? to get the vector from route
+    // TODO: Return the first stop or NavigationError::EmptyRoute
+}
+
+fn display_name(name: Option<&str>) -> &str {
+    // TODO: Use unwrap_or to return "traveler" when name is None
+}`,
+        solution: `enum NavigationError {
+    EmptyRoute,
+}
+
+fn first_stop(route: Result<Vec<&'static str>, NavigationError>) -> Result<&'static str, NavigationError> {
+    let stops = route?;
+    stops.first().copied().ok_or(NavigationError::EmptyRoute)
+}
+
+fn display_name(name: Option<&str>) -> &str {
+    name.unwrap_or("traveler")
+}`,
+        checks: [
+            { type: 'contains_pattern', pattern: 'enum NavigationError', message: "Missing 'NavigationError' enum", description: 'custom error enum' },
+            { type: 'has_function', name: 'first_stop', params: ["route: Result<Vec<&'static str>, NavigationError>"], message: "Missing 'first_stop(route: Result<Vec<&'static str>, NavigationError>)'" },
+            { type: 'returns_type', function: 'first_stop', returnType: "Result<&'static str, NavigationError>", message: "'first_stop' should return Result<&'static str, NavigationError>" },
+            { type: 'contains_pattern', pattern: 'route?', message: 'Use the ? operator to propagate route errors', description: '? operator' },
+            { type: 'contains_pattern', pattern: 'ok_or(NavigationError::EmptyRoute)', message: 'Convert the optional first stop into a Result', description: 'ok_or(...)' },
+            { type: 'has_function', name: 'display_name', params: ['name: Option<&str>'], message: "Missing 'display_name(name: Option<&str>)'" },
+            { type: 'contains_pattern', pattern: 'unwrap_or("traveler")', message: 'Use unwrap_or to provide the fallback name', description: 'unwrap_or fallback' },
+        ],
+        hints: [
+            'Start by extracting the vector with `let stops = route?;`.',
+            'Use `stops.first().copied().ok_or(...)` to return either the first item or a custom error.',
+            'For the fallback name, `name.unwrap_or("traveler")` is enough, and it is safer than a raw `unwrap()` here.',
+        ],
+        conceptsIntroduced: ['Result', 'unwrap', '? operator', 'unwrap_or', 'custom errors'],
+    },
+
     {
         id: 'hello-soroban',
         title: 'The First Contract',

--- a/src/index.css
+++ b/src/index.css
@@ -1005,6 +1005,38 @@ button {
   gap: var(--space-lg);
 }
 
+.mission-map-sections {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xl);
+}
+
+.mission-chapter-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.mission-chapter-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mission-chapter-heading h2 {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  color: var(--text-primary);
+}
+
+.mission-chapter-eyebrow {
+  font-family: var(--font-display);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: var(--cyan);
+}
+
 /* Learning path SVG */
 .learning-path {
   width: 100%;

--- a/src/pages/MissionMap.jsx
+++ b/src/pages/MissionMap.jsx
@@ -1,7 +1,7 @@
-import React, { useState, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { loadProgress } from '../systems/storage';
-import { getAllMissions, isMissionUnlocked } from '../systems/missionLoader';
+import { getAllMissions, getChapterTitle, isMissionUnlocked } from '../systems/missionLoader';
 
 export default function MissionMap() {
     const navigate = useNavigate();
@@ -15,6 +15,23 @@ export default function MissionMap() {
             unlocked: isMissionUnlocked(m.id, state.completedMissions),
         }));
     }, [state.completedMissions]);
+
+    const chapterSections = useMemo(() => {
+        const grouped = missionStates.reduce((acc, mission) => {
+            const chapter = mission.chapter ?? 1;
+            if (!acc[chapter]) acc[chapter] = [];
+            acc[chapter].push(mission);
+            return acc;
+        }, {});
+
+        return Object.entries(grouped)
+            .sort(([left], [right]) => Number(left) - Number(right))
+            .map(([chapter, items]) => ({
+                chapter: Number(chapter),
+                title: getChapterTitle(Number(chapter)),
+                missions: items,
+            }));
+    }, [missionStates]);
 
     const handleMissionClick = (mission) => {
         if (mission.unlocked) {
@@ -122,36 +139,46 @@ export default function MissionMap() {
             </div>
 
             {/* Mission Cards Grid */}
-            <div className="mission-map-grid">
-                {missionStates.map((m) => (
-                    <div
-                        key={m.id}
-                        className={`mission-card ${m.completed ? 'completed' : ''} ${!m.unlocked ? 'locked' : ''}`}
-                        onClick={() => handleMissionClick(m)}
-                    >
-                        <div className="mission-card-header">
-                            <span className="mission-card-chapter">Chapter {m.chapter} • Mission {m.order}</span>
-                            <span className="mission-card-xp">⚡ {m.xpReward} XP</span>
+            <div className="mission-map-sections">
+                {chapterSections.map(({ chapter, title, missions: chapterMissions }) => (
+                    <section key={chapter} className="mission-chapter-section">
+                        <div className="mission-chapter-heading">
+                            <span className="mission-chapter-eyebrow">Chapter {chapter}</span>
+                            <h2>{title}</h2>
                         </div>
-                        <h3 className="mission-card-title">{m.title}</h3>
-                        <p className="mission-card-desc">{m.learningGoal}</p>
-                        <div className="mission-card-footer">
-                            <div className="mission-card-concepts">
-                                {m.conceptsIntroduced.slice(0, 3).map(c => (
-                                    <span key={c} className="concept-tag">{c}</span>
-                                ))}
-                            </div>
-                            <span className={`badge badge-${m.difficulty}`}>
-                                {m.difficulty}
-                            </span>
+                        <div className="mission-map-grid">
+                            {chapterMissions.map((m) => (
+                                <div
+                                    key={m.id}
+                                    className={`mission-card ${m.completed ? 'completed' : ''} ${!m.unlocked ? 'locked' : ''}`}
+                                    onClick={() => handleMissionClick(m)}
+                                >
+                                    <div className="mission-card-header">
+                                        <span className="mission-card-chapter">Chapter {m.chapter} • Mission {m.order}</span>
+                                        <span className="mission-card-xp">⚡ {m.xpReward} XP</span>
+                                    </div>
+                                    <h3 className="mission-card-title">{m.title}</h3>
+                                    <p className="mission-card-desc">{m.learningGoal}</p>
+                                    <div className="mission-card-footer">
+                                        <div className="mission-card-concepts">
+                                            {m.conceptsIntroduced.slice(0, 3).map(c => (
+                                                <span key={c} className="concept-tag">{c}</span>
+                                            ))}
+                                        </div>
+                                        <span className={`badge badge-${m.difficulty}`}>
+                                            {m.difficulty}
+                                        </span>
+                                    </div>
+                                    {m.completed && (
+                                        <div className="mission-card-status completed">✓ Completed</div>
+                                    )}
+                                    {!m.unlocked && (
+                                        <div className="mission-card-status" style={{ color: 'var(--text-muted)' }}>🔒 Locked</div>
+                                    )}
+                                </div>
+                            ))}
                         </div>
-                        {m.completed && (
-                            <div className="mission-card-status completed">✓ Completed</div>
-                        )}
-                        {!m.unlocked && (
-                            <div className="mission-card-status" style={{ color: 'var(--text-muted)' }}>🔒 Locked</div>
-                        )}
-                    </div>
+                    </section>
                 ))}
             </div>
         </div>

--- a/src/systems/__tests__/missionLoader.test.js
+++ b/src/systems/__tests__/missionLoader.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import {
+  getAllMissions,
+  getChapterTitle,
+  getMissionsByChapter,
+  isMissionUnlocked,
+} from "../missionLoader.js";
+
+describe("missionLoader", () => {
+  it("groups chapter 0 missions separately", () => {
+    const chapters = getMissionsByChapter();
+
+    expect(chapters[0]).toHaveLength(5);
+    expect(chapters[0].every((mission) => mission.chapter === 0)).toBe(true);
+    expect(getChapterTitle(0)).toBe("Rust Fundamentals");
+  });
+
+  it("adds 450 XP across the Rust fundamentals chapter", () => {
+    const chapterZeroXP = getAllMissions()
+      .filter((mission) => mission.chapter === 0)
+      .reduce((total, mission) => total + mission.xpReward, 0);
+
+    expect(chapterZeroXP).toBe(450);
+  });
+
+  it("unlocks all chapter 0 missions by default", () => {
+    expect(isMissionUnlocked("rust-variables-and-types", [])).toBe(true);
+    expect(isMissionUnlocked("rust-error-handling", [])).toBe(true);
+  });
+
+  it("keeps the original chapter 1 progression intact", () => {
+    expect(isMissionUnlocked("hello-soroban", [])).toBe(true);
+    expect(isMissionUnlocked("greetings-protocol", [])).toBe(false);
+    expect(isMissionUnlocked("greetings-protocol", ["hello-soroban"])).toBe(true);
+  });
+});

--- a/src/systems/__tests__/testRunner.test.js
+++ b/src/systems/__tests__/testRunner.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { runTests } from "../testRunner.js";
+
+describe("testRunner", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("accepts pure Rust fundamentals missions without Soroban SDK markers", async () => {
+    vi.useFakeTimers();
+
+    const mission = {
+      chapter: 0,
+      checks: [{ type: "contains_pattern", pattern: "let value = 42;" }],
+    };
+
+    const code = `
+      fn fundamentals_demo() {
+        let value = 42;
+      }
+    `;
+
+    const resultPromise = runTests(code, mission);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.allPassed).toBe(true);
+  });
+
+  it("still requires Soroban markers for later chapters", async () => {
+    vi.useFakeTimers();
+
+    const mission = {
+      chapter: 1,
+      checks: [],
+    };
+
+    const code = `
+      fn fundamentals_demo() {
+        let value = 42;
+      }
+    `;
+
+    const resultPromise = runTests(code, mission);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.allPassed).toBe(false);
+    expect(result.results[1].message).toContain("Soroban SDK");
+  });
+});

--- a/src/systems/missionLoader.js
+++ b/src/systems/missionLoader.js
@@ -4,6 +4,13 @@
 
 import { missions } from '../data/missions';
 
+export const chapterTitles = {
+    0: 'Rust Fundamentals',
+    1: 'First Contracts',
+    2: 'State and Access',
+    3: 'Advanced Contracts',
+};
+
 export function getAllMissions() {
     return missions;
 }
@@ -15,11 +22,15 @@ export function getMissionById(id) {
 export function getMissionsByChapter() {
     const chapters = {};
     for (const mission of missions) {
-        const ch = mission.chapter || 1;
+        const ch = mission.chapter ?? 1;
         if (!chapters[ch]) chapters[ch] = [];
         chapters[ch].push(mission);
     }
     return chapters;
+}
+
+export function getChapterTitle(chapter) {
+    return chapterTitles[chapter] || `Chapter ${chapter}`;
 }
 
 export function getNextMission(currentId) {
@@ -38,11 +49,11 @@ export function isMissionUnlocked(missionId, completedMissions) {
     const mission = getMissionById(missionId);
     if (!mission) return false;
 
-    // First mission is always unlocked
-    const idx = missions.findIndex(m => m.id === missionId);
-    if (idx === 0) return true;
+    if (mission.chapter === 0) return true;
 
-    // Subsequent missions require the previous one to be completed
-    const prevMission = missions[idx - 1];
-    return completedMissions.includes(prevMission.id);
+    const coreMissions = missions.filter(m => (m.chapter ?? 1) > 0);
+    const idx = coreMissions.findIndex(m => m.id === missionId);
+    if (idx <= 0) return true;
+
+    return completedMissions.includes(coreMissions[idx - 1].id);
 }

--- a/src/systems/testRunner.js
+++ b/src/systems/testRunner.js
@@ -97,6 +97,18 @@ function checkStructure(code, mission) {
         return { passed: false, message: '✗ No function definitions found' };
     }
 
+    if (mission.chapter === 0) {
+        const hasSorobanMarkers =
+            code.includes('soroban_sdk') ||
+            code.includes('contractimpl') ||
+            code.includes('contract') ||
+            code.includes('Env');
+
+        return !hasSorobanMarkers
+            ? { passed: true, message: '✓ Rust fundamentals structure validated' }
+            : { passed: false, message: '✗ Chapter 0 missions must use pure Rust without Soroban SDK patterns' };
+    }
+
     // Should have Soroban-related content
     const hasSorobanMarkers =
         code.includes('soroban_sdk') ||


### PR DESCRIPTION
## What does this PR do?
Introduces a new introductory learning path, "Chapter 0: Rust Fundamentals", so learners can build the Rust foundation they need before starting the existing Soroban contract missions.

This PR adds five new onboarding missions that progressively cover variables and types, functions and returns, structs and enums, pattern matching, and error handling. It also updates the supporting mission flow so these exercises behave correctly as pure Rust content without changing the existing Soroban chapters.

## Related issue
Closes #41

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Content (new mission or educational material)
- [ ] Documentation
- [ ] Refactor

## Testing checklist
- [x] `npm run build` passes
- [ ] `npm run lint` passes (if available)
- [x] Tested locally in the browser
- [x] All existing pages still work correctly
- [ ] Screenshots attached (if UI change)

## Implementation details
- added 5 Chapter 0 missions in `src/data/missions.js`, each with story content, starter template, reference solution, validation checks, hints, and `conceptsIntroduced` metadata
- ensured all Chapter 0 missions use pure Rust syntax with no Soroban SDK imports
- updated `missionLoader.js` so all Chapter 0 missions are unlocked by default while preserving the existing Chapter 1-3 progression
- updated the Mission Map to display Chapter 0 clearly as "Rust Fundamentals"
- adjusted the mission test runner so Chapter 0 exercises validate as pure Rust exercises instead of requiring Soroban contract structure
- added automated test coverage for Chapter 0 grouping, XP totals, unlock behavior, and Rust-only validation behavior

## Validation summary
This PR was validated locally with:
- `npm test`
- `npm run build`

Both commands completed successfully.

## Backward compatibility
- existing Chapter 1-3 mission content was left unchanged
- the original Soroban mission progression remains intact
- total available XP increases by 450, as requested in the issue

## Screenshots
Not included.
