### PR TITLE
feat: add dark/light theme toggle with persistent preference

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,13 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&family=Orbitron:wght@400;500;600;700;800;900&display=swap" rel="stylesheet" />
+    <script>
+      // Apply saved theme before render to prevent FOUC
+      (function() {
+        var theme = localStorage.getItem('soroban_quest_theme') || 'dark';
+        document.documentElement.setAttribute('data-theme', theme);
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,12 +1,27 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { loadProgress } from '../systems/storage';
 import { getRankTitle, getXPProgress } from '../systems/gameEngine';
+
+const THEME_KEY = 'soroban_quest_theme';
 
 export default function Navbar() {
     const location = useLocation();
     const state = loadProgress();
     const xpProgress = getXPProgress(state);
+
+    const [theme, setTheme] = useState(() => {
+        return document.documentElement.getAttribute('data-theme') || 'dark';
+    });
+
+    useEffect(() => {
+        document.documentElement.setAttribute('data-theme', theme);
+        localStorage.setItem(THEME_KEY, theme);
+    }, [theme]);
+
+    const toggleTheme = () => {
+        setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+    };
 
     const isActive = (path) => location.pathname === path ? 'active' : '';
 
@@ -33,6 +48,33 @@ export default function Navbar() {
             </ul>
 
             <div className="navbar-stats">
+                <button
+                    className="theme-toggle"
+                    onClick={toggleTheme}
+                    aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+                    title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+                    id="theme-toggle-btn"
+                >
+                    {theme === 'dark' ? (
+                        /* Sun icon — shown in dark mode, click to go light */
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <circle cx="12" cy="12" r="5" />
+                            <line x1="12" y1="1" x2="12" y2="3" />
+                            <line x1="12" y1="21" x2="12" y2="23" />
+                            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+                            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+                            <line x1="1" y1="12" x2="3" y2="12" />
+                            <line x1="21" y1="12" x2="23" y2="12" />
+                            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+                            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+                        </svg>
+                    ) : (
+                        /* Moon icon — shown in light mode, click to go dark */
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+                        </svg>
+                    )}
+                </button>
                 <div className="navbar-xp">
                     ⚡ {state.xp} XP
                 </div>

--- a/src/index.css
+++ b/src/index.css
@@ -12,17 +12,17 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  background: #020617;
-  color: white;
+  background: var(--bg-primary);
+  color: var(--text-primary);
   padding: 30px;
 }
 
 .notfound-card {
   text-align: center;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--bg-card);
   padding: 40px;
   border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border-subtle);
   max-width: 400px;
   width: 100%;
   animation: float 3s ease-in-out infinite;
@@ -30,22 +30,22 @@
 
 .notfound-card h1 {
   font-size: 70px;
-  color: #22c55e;
+  color: var(--green);
 }
 
 .home-btn {
   display: inline-block;
   margin-top: 20px;
   padding: 10px 20px;
-  background: #22c55e;
-  color: black;
+  background: var(--green);
+  color: var(--bg-primary);
   border-radius: 8px;
   text-decoration: none;
   transition: 0.3s;
 }
 
 .home-btn:hover {
-  background: #16a34a;
+  background: var(--cyan);
 }
 
 @keyframes float {
@@ -56,11 +56,12 @@
 
 /*foot style*/
 .footer {
-  background-color: #1e1e2f;
-  color: #a0a0b0;
+  background-color: var(--bg-secondary);
+  color: var(--text-secondary);
   padding: 2rem 1rem;
   text-align: center;
   font-family: Arial, sans-serif;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .footer-content {
@@ -74,7 +75,7 @@
 
 .footer-section h4 {
   margin-bottom: 0.75rem;
-  color: #ffffff;
+  color: var(--text-primary);
   font-size: 1.1rem;
 }
 
@@ -89,22 +90,22 @@
 }
 
 .footer-section a {
-  color: #a0a0b0;
+  color: var(--text-secondary);
   text-decoration: none;
   transition: color 0.2s ease;
 }
 
 .footer-section a:hover {
-  color: #00d4ff;
+  color: var(--cyan);
   text-decoration: underline;
 }
 
 .footer-credits {
   margin-top: 2rem;
   font-size: 0.875rem;
-  border-top: 1px solid #2c2c3c;
+  border-top: 1px solid var(--border-subtle);
   padding-top: 1rem;
-  color: #888;
+  color: var(--text-muted);
 }
 
 /* Mobile: 2 columns per row */
@@ -123,7 +124,7 @@
 
 /* Base skeleton style */
 .skeleton {
-  background-color: #374151; /* dark gray */
+  background-color: var(--bg-tertiary);
   border-radius: 6px;
   position: relative;
   overflow: hidden;
@@ -251,6 +252,107 @@
   --z-toast: 300;
 }
 
+/* ============ LIGHT THEME ============ */
+[data-theme="light"] {
+  /* Core palette — warm parchment RPG tones */
+  --bg-primary: #f5f0e8;
+  --bg-secondary: #ece5d8;
+  --bg-tertiary: #e0d8c8;
+  --bg-card: rgba(236, 229, 216, 0.85);
+  --bg-glass: rgba(245, 240, 232, 0.8);
+
+  /* Text */
+  --text-primary: #1a1612;
+  --text-secondary: #4a4438;
+  --text-muted: #7a7264;
+
+  /* Borders */
+  --border-subtle: rgba(74, 68, 56, 0.15);
+  --border-accent: rgba(5, 150, 110, 0.4);
+  --border-glow: rgba(5, 150, 110, 0.6);
+
+  /* Accent color adjustments for light backgrounds */
+  --cyan: #059669;
+  --cyan-dim: rgba(5, 150, 105, 0.12);
+  --cyan-glow: rgba(5, 150, 105, 0.25);
+  --purple: #7c3aed;
+  --purple-dim: rgba(124, 58, 237, 0.1);
+  --purple-glow: rgba(124, 58, 237, 0.25);
+  --gold: #d97706;
+  --gold-dim: rgba(217, 119, 6, 0.1);
+  --gold-glow: rgba(217, 119, 6, 0.25);
+  --red: #dc2626;
+  --red-dim: rgba(220, 38, 38, 0.1);
+  --green: #16a34a;
+  --green-dim: rgba(22, 163, 74, 0.1);
+  --blue: #2563eb;
+  --blue-dim: rgba(37, 99, 235, 0.1);
+
+  /* Shadows */
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.08);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.12);
+  --shadow-glow-cyan: 0 0 20px var(--cyan-glow), 0 0 60px rgba(5, 150, 105, 0.05);
+  --shadow-glow-purple: 0 0 20px var(--purple-glow), 0 0 60px rgba(124, 58, 237, 0.05);
+  --shadow-glow-gold: 0 0 20px var(--gold-glow), 0 0 60px rgba(217, 119, 6, 0.05);
+}
+
+/* Light theme: softer body background gradient */
+[data-theme="light"] body::before {
+  background:
+    radial-gradient(ellipse at 20% 50%, rgba(5, 150, 105, 0.05) 0%, transparent 50%),
+    radial-gradient(ellipse at 80% 20%, rgba(124, 58, 237, 0.06) 0%, transparent 50%),
+    radial-gradient(ellipse at 50% 80%, rgba(37, 99, 235, 0.04) 0%, transparent 50%),
+    var(--bg-primary);
+}
+
+/* Light theme: softer modal overlay */
+[data-theme="light"] .modal-overlay {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+/* Light theme: scrollbar */
+[data-theme="light"] ::-webkit-scrollbar-track {
+  background: var(--bg-secondary);
+}
+
+[data-theme="light"] ::-webkit-scrollbar-thumb {
+  background: var(--bg-tertiary);
+}
+
+/* ============ THEME TOGGLE ============ */
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-full);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-base);
+  flex-shrink: 0;
+}
+
+.theme-toggle:hover {
+  color: var(--gold);
+  border-color: rgba(245, 158, 11, 0.3);
+  background: var(--gold-dim);
+  transform: rotate(15deg);
+}
+
+.theme-toggle svg {
+  width: 18px;
+  height: 18px;
+  transition: transform 0.3s ease;
+}
+
+.theme-toggle:hover svg {
+  transform: scale(1.15);
+}
+
 /* ============ RESET ============ */
 *, *::before, *::after {
   margin: 0;
@@ -272,6 +374,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   overflow-x: hidden;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 /* Animated background */
@@ -612,12 +715,16 @@ button {
 
 /* ============ TERMINAL ============ */
 .terminal {
-  background: #0d1117;
+  background: var(--bg-primary);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
   font-family: var(--font-code);
   font-size: 0.85rem;
   overflow: hidden;
+}
+
+[data-theme="dark"] .terminal {
+  background: #0d1117;
 }
 
 .terminal-header {

--- a/src/pages/MissionDetail.jsx
+++ b/src/pages/MissionDetail.jsx
@@ -292,7 +292,7 @@ export default function MissionDetail() {
               defaultLanguage="rust"
               value={code}
               onChange={(v) => setCode(v || "")}
-              theme="vs-dark"
+              theme={document.documentElement.getAttribute('data-theme') === 'light' ? 'light' : 'vs-dark'}
               options={{
                 fontSize: 14,
                 fontFamily: "'JetBrains Mono', 'Fira Code', monospace",


### PR DESCRIPTION
Fixes #61

## Related issue
Closes #61 

Added dark/light theme toggle and saved user preference in local storage.

Changes:
- Added a theme toggle button in Navbar.jsx
- Set up CSS variables for light/dark colors in index.css
- Added a script in index.html to check local storage on load to prevent FOUC (flash of unstyled content)
- Updated hardcoded dark colors in MissionDetail.jsx to use the new theme variables


## Screenshots
<img width="1919" height="902" alt="image" src="https://github.com/user-attachments/assets/7407eba4-5f5d-4270-bc68-f8b34f939454" />
<img width="1919" height="908" alt="image" src="https://github.com/user-attachments/assets/87c94f82-0f16-4e79-ae1e-93d32ef13c4c" />
<img width="1919" height="900" alt="image" src="https://github.com/user-attachments/assets/88a8f7db-eb87-4e3c-b930-f19ffcce238c" />
