### PR TITLE
feat: implement quest journal with narrative activity timeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1314,6 +1315,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1324,8 +1326,7 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -1521,6 +1522,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1696,7 +1698,6 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -2046,7 +2047,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -2748,6 +2748,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2799,6 +2800,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2811,6 +2813,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3280,6 +3283,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,13 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Routes, Route } from "react-router-dom";
+import { loadProgress, saveProgress } from "./systems/storage";
+import { updateStreak } from "./systems/gameEngine";
 import Navbar from "./components/Navbar";
 import Home from "./pages/Home";
 import MissionMap from "./pages/MissionMap";
 import MissionDetail from "./pages/MissionDetail";
 import Profile from "./pages/Profile";
+import Journal from "./pages/Journal";
 import Footer from "./components/Footer";
 import NotFound from "./pages/NotFound";
 
@@ -16,6 +19,12 @@ import { ToastProvider } from "./systems/ToastContext";
 import "./systems/Toast.css";
 
 export default function App() {
+  useEffect(() => {
+    const state = loadProgress();
+    const newState = updateStreak(state);
+    saveProgress(newState);
+  }, []);
+
   return (
     <ErrorBoundary>
       {/* 3. Wraped everything in ToastProvider */}
@@ -28,6 +37,7 @@ export default function App() {
               <Route path="/missions" element={<MissionMap />} />
               <Route path="/mission/:missionId" element={<MissionDetail />} />
               <Route path="/profile" element={<Profile />} />
+              <Route path="/journal" element={<Journal />} />
               <Route path="*" element={<NotFound />} />
             </Routes>
           </main>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -48,6 +48,11 @@ export default function Navbar() {
             Profile
           </Link>
         </li>
+        <li>
+          <Link to="/journal" className={isActive("/journal")}>
+            Journal
+          </Link>
+        </li>
       </ul>
 
       {/* PROFILE DISPLAY & THEME TOGGLE (DESKTOP) */}
@@ -77,6 +82,9 @@ export default function Navbar() {
         </Link>
         <Link to="/profile" onClick={() => setIsOpen(false)}>
           Profile
+        </Link>
+        <Link to="/journal" onClick={() => setIsOpen(false)}>
+          Journal
         </Link>
 
         {/* MOBILE EXTRAS */}

--- a/src/pages/Journal.css
+++ b/src/pages/Journal.css
@@ -1,0 +1,200 @@
+/* ==========================================
+   Journal / Activity Log Styles
+   ========================================== */
+
+.journal-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: var(--space-xl) var(--space-md);
+}
+
+.journal-header {
+  margin-bottom: var(--space-xl);
+}
+
+.journal-title {
+  font-size: 2.5rem;
+  font-weight: 800;
+  margin-bottom: var(--space-sm);
+  background: linear-gradient(135deg, var(--text-primary) 0%, var(--text-secondary) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+/* Summary Card */
+.adventure-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: var(--space-md);
+  margin-bottom: var(--space-xl);
+}
+
+.summary-stat {
+  background: var(--bg-glass);
+  backdrop-filter: blur(10px);
+  padding: var(--space-lg);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+  text-align: center;
+  transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.summary-stat:hover {
+  transform: translateY(-5px);
+  border-color: var(--cyan-dim);
+}
+
+.summary-stat-value {
+  display: block;
+  font-size: 2rem;
+  font-weight: 800;
+  color: var(--cyan);
+  margin-bottom: 4px;
+}
+
+.summary-stat-label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+/* Filters */
+.journal-filters {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: var(--space-lg);
+  flex-wrap: wrap;
+}
+
+.filter-chip {
+  padding: 0.5rem 1rem;
+  border-radius: 100px;
+  background: var(--bg-glass);
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.filter-chip:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--text-muted);
+}
+
+.filter-chip.active {
+  background: var(--cyan-dim);
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+
+/* Timeline */
+.timeline {
+  position: relative;
+  padding-left: 2rem;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 0.75rem;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(to bottom, 
+    var(--cyan) 0%, 
+    var(--purple) 50%, 
+    var(--gold) 100%);
+  opacity: 0.3;
+}
+
+.date-group {
+  margin-bottom: var(--space-xl);
+}
+
+.date-header {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  margin-bottom: var(--space-lg);
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.date-header::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border-color);
+}
+
+.timeline-event {
+  position: relative;
+  padding-bottom: var(--space-xl);
+}
+
+.event-dot {
+  position: absolute;
+  left: -2rem;
+  top: 0.25rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  background: var(--bg-secondary);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.8rem;
+  z-index: 2;
+  border: 2px solid var(--border-color);
+  box-shadow: 0 0 15px rgba(0,0,0,0.3);
+}
+
+.event-content {
+  background: var(--bg-glass);
+  padding: var(--space-md) var(--space-lg);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  transition: all 0.3s ease;
+}
+
+.event-content:hover {
+  border-color: rgba(255,255,255,0.15);
+  background: rgba(255,255,255,0.03);
+  transform: translateX(5px);
+}
+
+.event-time {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.event-message {
+  font-size: 1rem;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.event-details {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 4px;
+}
+
+/* Event Types Colors */
+.event-dot.mission { border-color: var(--cyan); color: var(--cyan); }
+.event-dot.badge { border-color: var(--gold); color: var(--gold); }
+.event-dot.level { border-color: var(--purple); color: var(--purple); }
+.event-dot.hint { border-color: var(--red); color: var(--red); }
+.event-dot.system { border-color: var(--text-muted); color: var(--text-muted); }
+
+@media (max-width: 600px) {
+  .journal-title { font-size: 2rem; }
+  .adventure-summary { grid-template-columns: 1fr 1fr; }
+}

--- a/src/pages/Journal.jsx
+++ b/src/pages/Journal.jsx
@@ -1,0 +1,158 @@
+import React, { useState, useMemo } from "react";
+import { getActivityLog, ACTIVITY_TYPES, clearLog } from "../systems/activityLogger";
+import { loadProgress } from "../systems/storage";
+import "./Journal.css";
+
+const EVENT_CONFIG = {
+  [ACTIVITY_TYPES.MISSION_STARTED]: { icon: "⚔️", class: "mission", label: "Mission" },
+  [ACTIVITY_TYPES.MISSION_COMPLETED]: { icon: "🗡️", class: "mission", label: "Mission" },
+  [ACTIVITY_TYPES.BADGE_EARNED]: { icon: "🏅", class: "badge", label: "Badge" },
+  [ACTIVITY_TYPES.LEVEL_UP]: { icon: "⬆️", class: "level", label: "Level Up" },
+  [ACTIVITY_TYPES.HINT_USED]: { icon: "💡", class: "hint", label: "Hint" },
+  [ACTIVITY_TYPES.EXPORT]: { icon: "📤", class: "system", label: "System" },
+  [ACTIVITY_TYPES.IMPORT]: { icon: "📥", class: "system", label: "System" },
+  [ACTIVITY_TYPES.STREAK]: { icon: "🔥", class: "system", label: "Streak" },
+};
+
+export default function Journal() {
+  const [log, setLog] = useState(() => getActivityLog());
+  const [filter, setFilter] = useState("ALL");
+  const progress = loadProgress();
+
+  const filteredLog = useMemo(() => {
+    if (filter === "ALL") return log;
+    return log.filter(entry => {
+      const config = EVENT_CONFIG[entry.type];
+      return config && config.label.toUpperCase() === filter;
+    });
+  }, [log, filter]);
+
+  // Group by date
+  const groupedLog = useMemo(() => {
+    const groups = {};
+    filteredLog.forEach(entry => {
+      const date = new Date(entry.timestamp);
+      const dateStr = formatDateHeader(date);
+      if (!groups[dateStr]) groups[dateStr] = [];
+      groups[dateStr].push(entry);
+    });
+    return groups;
+  }, [filteredLog]);
+
+  const handleClear = () => {
+    if (window.confirm("Clear all activity history?")) {
+      clearLog();
+      setLog([]);
+    }
+  };
+
+  return (
+    <div className="journal-page">
+      <div className="journal-header flex justify-between items-end">
+        <div>
+          <h1 className="journal-title">Adventure Journal</h1>
+          <p className="text-secondary">Your journey through the Soroban realm, recorded for eternity.</p>
+        </div>
+        <button className="btn btn-ghost btn-sm" style={{ color: "var(--red)" }} onClick={handleClear}>
+          🗑️ Clear Log
+        </button>
+      </div>
+
+      {/* Summary Stats */}
+      <div className="adventure-summary">
+        <div className="summary-stat">
+          <span className="summary-stat-value">{progress.completedMissions.length}</span>
+          <span className="summary-stat-label">Missions</span>
+        </div>
+        <div className="summary-stat">
+          <span className="summary-stat-value">{progress.badges.length}</span>
+          <span className="summary-stat-label">Badges</span>
+        </div>
+        <div className="summary-stat">
+          <span className="summary-stat-value">{progress.level}</span>
+          <span className="summary-stat-label">Level</span>
+        </div>
+        <div className="summary-stat">
+          <span className="summary-stat-value">{progress.xp}</span>
+          <span className="summary-stat-label">Total XP</span>
+        </div>
+        <div className="summary-stat">
+          <span className="summary-stat-value">{progress.streak || 0}</span>
+          <span className="summary-stat-label">Day Streak</span>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="journal-filters">
+        {["ALL", "MISSION", "BADGE", "LEVEL UP", "HINT", "SYSTEM"].map(f => (
+          <button 
+            key={f} 
+            className={`filter-chip ${filter === f ? "active" : ""}`}
+            onClick={() => setFilter(f)}
+          >
+            {f}
+          </button>
+        ))}
+      </div>
+
+      {/* Timeline */}
+      {Object.keys(groupedLog).length === 0 ? (
+        <div className="card text-center p-12">
+          <div style={{ fontSize: "3rem", marginBottom: "1rem opacity: 0.3" }}>📖</div>
+          <p className="text-secondary">No activities recorded yet. Start your first mission!</p>
+        </div>
+      ) : (
+        <div className="timeline">
+          {Object.entries(groupedLog).map(([date, entries]) => (
+            <div key={date} className="date-group">
+              <div className="date-header">{date}</div>
+              {entries.map(entry => {
+                const config = EVENT_CONFIG[entry.type] || { icon: "❓", class: "system" };
+                const time = new Date(entry.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+                
+                return (
+                  <div key={entry.id} className="timeline-event">
+                    <div className={`event-dot ${config.class}`}>
+                      {config.icon}
+                    </div>
+                    <div className="event-content">
+                      <div className="event-time">{time}</div>
+                      <div className="event-message">{entry.message}</div>
+                      {entry.data && Object.keys(entry.data).length > 0 && (
+                        <div className="event-details">
+                          {entry.type === ACTIVITY_TYPES.LEVEL_UP && `Target XP reached: ${progress.xp}`}
+                          {entry.type === ACTIVITY_TYPES.MISSION_COMPLETED && `Earned ${entry.data.xp || ""} XP`}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatDateHeader(date) {
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  if (isSameDay(date, today)) return "Today";
+  if (isSameDay(date, yesterday)) return "Yesterday";
+
+  return date.toLocaleDateString("en-US", { 
+    month: "long", 
+    day: "numeric", 
+    year: date.getFullYear() !== today.getFullYear() ? "numeric" : undefined 
+  });
+}
+
+function isSameDay(d1, d2) {
+  return d1.getFullYear() === d2.getFullYear() &&
+         d1.getMonth() === d2.getMonth() &&
+         d1.getDate() === d2.getDate();
+}

--- a/src/pages/MissionDetail.jsx
+++ b/src/pages/MissionDetail.jsx
@@ -5,11 +5,8 @@ import ReactMarkdown from "react-markdown";
 import { getMissionById, getNextMission } from "../systems/missionLoader";
 import { runTests } from "../systems/testRunner";
 import { loadProgress, saveProgress } from "../systems/storage";
-import {
-  completeMission,
-  recordAttempt,
-  getRankTitle,
-} from "../systems/gameEngine";
+import { completeMission, recordAttempt, getRankTitle } from "../systems/gameEngine";
+import { logActivity, ACTIVITY_TYPES } from "../systems/activityLogger";
 import MissionDetailSkeleton from "../components/MissionDetailSkeleton";
 import { useokashi } from "../systems/useokashi";
 
@@ -51,6 +48,7 @@ export default function MissionDetail() {
         setHintIndex(-1);
         setShowVictory(false);
         setLoading(false);
+        logActivity(ACTIVITY_TYPES.MISSION_STARTED, { missionId, title: mission.title }, `Started mission: ${mission.title}`);
       }, 1500);
     } else {
       setLoading(false);
@@ -123,6 +121,7 @@ export default function MissionDetail() {
       const nextIndex = hintIndex + 1;
       setHintIndex(nextIndex);
       if (showToast) showToast(`Hint ${nextIndex + 1} unlocked`, "info");
+      logActivity(ACTIVITY_TYPES.HINT_USED, { missionId, hintIndex: nextIndex }, `Used hint ${nextIndex + 1} for ${mission.title}`);
     }
   };
 

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef } from "react";
+import { Link } from "react-router-dom";
 import {
   loadProgress,
   importProgress,
@@ -11,6 +12,7 @@ import {
 import { getXPProgress, getRankTitle, BADGES } from "../systems/gameEngine";
 import { getAllMissions } from "../systems/missionLoader";
 import { avatars } from "../data/avatars";
+import { logActivity, ACTIVITY_TYPES } from "../systems/activityLogger";
 
 export default function Profile() {
   const [state, setState] = useState(loadProgress());
@@ -52,6 +54,7 @@ export default function Profile() {
   const handleExport = () => {
     exportProgress();
     setImportStatus("✅ Progress exported!");
+    logActivity(ACTIVITY_TYPES.EXPORT, {}, "Exported adventure progress");
     setTimeout(() => setImportStatus(""), 3000);
   };
 
@@ -63,6 +66,7 @@ export default function Profile() {
       const newState = await importProgress(file);
       setState(newState);
       setImportStatus("✅ Progress imported successfully!");
+      logActivity(ACTIVITY_TYPES.IMPORT, {}, "Imported adventure progress from file");
     } catch {
       setImportStatus("❌ Invalid file — could not import.");
     }
@@ -112,10 +116,15 @@ export default function Profile() {
             </div>
           </div>
 
-          {/* EDIT BUTTON */}
-          <button className="btn btn-secondary mt-3" onClick={openEdit}>
-            ✏️ Edit Profile
-          </button>
+          {/* ACTIONS */}
+          <div className="flex gap-2 mt-3">
+            <button className="btn btn-secondary" onClick={openEdit}>
+              ✏️ Edit Profile
+            </button>
+            <Link to="/journal" className="btn btn-ghost">
+              📖 View Journal
+            </Link>
+          </div>
         </div>
 
         {/* STATS */}

--- a/src/systems/activityLogger.js
+++ b/src/systems/activityLogger.js
@@ -1,0 +1,70 @@
+/* ==========================================
+   Activity Logger — Quest Journal System
+   ========================================== */
+
+const LOG_KEY = "soroban_quest_activity_log";
+const MAX_LOG_SIZE = 200;
+
+/**
+ * Log types for different activities
+ */
+export const ACTIVITY_TYPES = {
+  MISSION_STARTED: "MISSION_STARTED",
+  MISSION_COMPLETED: "MISSION_COMPLETED",
+  BADGE_EARNED: "BADGE_EARNED",
+  LEVEL_UP: "LEVEL_UP",
+  HINT_USED: "HINT_USED",
+  EXPORT: "EXPORT",
+  IMPORT: "IMPORT",
+  STREAK: "STREAK",
+};
+
+/**
+ * Logs a new activity to localStorage
+ * @param {string} type - Use ACTIVITY_TYPES
+ * @param {object} data - Metadata for the event (e.g., missionId, badgeName)
+ * @param {string} message - Human-readable description
+ */
+export function logActivity(type, data = {}, message = "") {
+  try {
+    const log = getActivityLog();
+    
+    const newEntry = {
+      id: Date.now() + Math.random().toString(36).substr(2, 9),
+      timestamp: new Date().toISOString(),
+      type,
+      data,
+      message
+    };
+
+    // Prepend to show newest first, then trim to max size
+    const updatedLog = [newEntry, ...log].slice(0, MAX_LOG_SIZE);
+    
+    localStorage.setItem(LOG_KEY, JSON.stringify(updatedLog));
+    
+    // Dispatch custom event for real-time UI updates if needed
+    window.dispatchEvent(new CustomEvent("activity_logged", { detail: newEntry }));
+  } catch (error) {
+    console.error("Failed to log activity:", error);
+  }
+}
+
+/**
+ * Retrieves the activity log from localStorage
+ * @returns {Array} List of activity objects
+ */
+export function getActivityLog() {
+  try {
+    const data = localStorage.getItem(LOG_KEY);
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Clears the activity log
+ */
+export function clearLog() {
+  localStorage.removeItem(LOG_KEY);
+}

--- a/src/systems/gameEngine.js
+++ b/src/systems/gameEngine.js
@@ -1,6 +1,8 @@
 /* ==========================================
    Game Engine — XP, Levels, Badges
    ========================================== */
+import { logActivity, ACTIVITY_TYPES } from "./activityLogger";
+
 
 const LEVEL_BASE = 500;
 const LEVEL_EXPONENT = 1.5;
@@ -87,6 +89,8 @@ function getDefaultState() {
     firstTryMissions: [],
     currentMission: null,
     missionAttempts: {},
+    streak: 0,
+    lastLogin: null,
   };
 }
 
@@ -129,6 +133,10 @@ export function awardXP(state, amount) {
   const newLevel = getLevelFromXP(newXP);
   const leveledUp = newLevel > state.level;
 
+  if (leveledUp) {
+    logActivity(ACTIVITY_TYPES.LEVEL_UP, { level: newLevel }, `Reached Level ${newLevel}!`);
+  }
+
   return {
     ...state,
     xp: newXP,
@@ -156,6 +164,8 @@ export function completeMission(state, missionId, xpReward) {
   newState = awardXP(newState, xpReward);
   newState = checkBadges(newState);
 
+  logActivity(ACTIVITY_TYPES.MISSION_COMPLETED, { missionId }, `Successfully completed mission: ${missionId}`);
+
   return newState;
 }
 
@@ -174,6 +184,7 @@ export function checkBadges(state) {
   for (const badge of BADGES) {
     if (!state.badges.includes(badge.id) && badge.condition(state)) {
       newBadges.push(badge.id);
+      logActivity(ACTIVITY_TYPES.BADGE_EARNED, { badgeId: badge.id, badgeName: badge.name }, `Earned the "${badge.name}" badge!`);
     }
   }
 
@@ -181,6 +192,33 @@ export function checkBadges(state) {
     ...state,
     badges: [...state.badges, ...newBadges],
     newBadges,
+  };
+}
+
+export function updateStreak(state) {
+  const today = new Date().toISOString().split("T")[0];
+  const lastLogin = state.lastLogin;
+
+  if (lastLogin === today) return state;
+
+  let newStreak = 1;
+  if (lastLogin) {
+    const last = new Date(lastLogin);
+    const now = new Date(today);
+    const diffTime = Math.abs(now - last);
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+    if (diffDays === 1) {
+      newStreak = (state.streak || 0) + 1;
+    }
+  }
+
+  logActivity(ACTIVITY_TYPES.STREAK, { streak: newStreak }, `Daily streak: ${newStreak} day${newStreak > 1 ? 's' : ''}!`);
+
+  return {
+    ...state,
+    streak: newStreak,
+    lastLogin: today,
   };
 }
 


### PR DESCRIPTION
## What does this PR do?
This PR introduces a comprehensive quest journal system with a narrative activity timeline. It adds an `activityLogger` for tracking user events, implements a Journal page with a vertically structured timeline grouped by date, and integrates logging across missions, badges, levels, and hint usage. It also includes daily streak tracking logic and updates navigation by adding links to the Navbar and Profile page.

## Related issue
Closes #69

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Content (new mission or educational material)
- [ ] Documentation
- [ ] Refactor

## Testing checklist
- [ ] `npm run build` passes
- [ ] `npm run lint` passes (if available)
- [ ] Tested locally in the browser
- [ ] All existing pages still work correctly
- [ ] Screenshots attached

## Screenshots
<img width="943" height="274" alt="Screenshot 2026-04-28 001026" src="https://github.com/user-attachments/assets/9155b4e9-7231-4292-bc83-4ee849fbe588" />
