### PR TITLE
feat: implement CTF game mode with security challenges (#67)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import MissionMap from "./pages/MissionMap";
 import MissionDetail from "./pages/MissionDetail";
 import Profile from "./pages/Profile";
 import Campaigns from "./pages/Campaigns";
+import CTFMode from "./pages/CTFMode";
 import Footer from "./components/Footer";
 import NotFound from "./pages/NotFound";
 
@@ -33,6 +34,7 @@ export default function App() {
               <Route path="/campaigns" element={<Campaigns />} />
               <Route path="/mission/:missionId" element={<MissionDetail />} />
               <Route path="/profile" element={<Profile />} />
+              <Route path="/ctf" element={<CTFMode />} />
               <Route path="*" element={<NotFound />} />
             </Routes>
           </main>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -53,6 +53,11 @@ export default function Navbar() {
           </Link>
         </li>
         <li>
+          <Link to="/ctf" className={isActive("/ctf")}>
+            CTF
+          </Link>
+        </li>
+        <li>
           <Link to="/profile" className={isActive("/profile")}>
             Profile
           </Link>
@@ -91,6 +96,9 @@ export default function Navbar() {
         </Link>
         <Link to="/missions" onClick={() => setIsOpen(false)}>
           Missions
+        </Link>
+        <Link to="/ctf" onClick={() => setIsOpen(false)}>
+          CTF
         </Link>
         <Link to="/profile" onClick={() => setIsOpen(false)}>
           Profile

--- a/src/data/ctfChallenges.js
+++ b/src/data/ctfChallenges.js
@@ -1,0 +1,610 @@
+/* ==========================================
+   CTF Challenges — Security-focused exploits
+   for intentionally vulnerable Soroban contracts
+   ========================================== */
+
+export const ctfChallenges = [
+  {
+    id: 'reentrancy-exploit',
+    title: 'Reentrancy Exploit',
+    order: 1,
+    difficulty: 'beginner',
+    xpReward: 150,
+    category: 'Access Control',
+    icon: '🔄',
+    description:
+      'A vault contract forgets to check authorization before releasing funds. Find the missing guard and write the fix.',
+    objective:
+      'Add `caller.require_auth()` before the withdrawal and ensure the balance check happens before the deduction.',
+    vulnerableContract: `#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct VaultContract;
+
+#[contractimpl]
+impl VaultContract {
+    pub fn deposit(env: Env, caller: Address, amount: i128) {
+        caller.require_auth();
+        let bal: i128 = env.storage().persistent().get(&caller).unwrap_or(0);
+        env.storage().persistent().set(&caller, &(bal + amount));
+    }
+
+    // 🐛 VULNERABILITY: No auth check — anyone can drain any account!
+    pub fn withdraw(env: Env, caller: Address, amount: i128) {
+        let bal: i128 = env.storage().persistent().get(&caller).unwrap_or(0);
+        env.storage().persistent().set(&caller, &(bal - amount));
+    }
+}`,
+    template: `#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct VaultContract;
+
+#[contractimpl]
+impl VaultContract {
+    pub fn deposit(env: Env, caller: Address, amount: i128) {
+        caller.require_auth();
+        let bal: i128 = env.storage().persistent().get(&caller).unwrap_or(0);
+        env.storage().persistent().set(&caller, &(bal + amount));
+    }
+
+    // TODO: Fix the withdraw function
+    // 1. Add require_auth() for the caller
+    // 2. Check that bal >= amount before subtracting (panic if not)
+    pub fn withdraw(env: Env, caller: Address, amount: i128) {
+        let bal: i128 = env.storage().persistent().get(&caller).unwrap_or(0);
+        env.storage().persistent().set(&caller, &(bal - amount));
+    }
+}`,
+    solution: `#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct VaultContract;
+
+#[contractimpl]
+impl VaultContract {
+    pub fn deposit(env: Env, caller: Address, amount: i128) {
+        caller.require_auth();
+        let bal: i128 = env.storage().persistent().get(&caller).unwrap_or(0);
+        env.storage().persistent().set(&caller, &(bal + amount));
+    }
+
+    pub fn withdraw(env: Env, caller: Address, amount: i128) {
+        caller.require_auth();
+        let bal: i128 = env.storage().persistent().get(&caller).unwrap_or(0);
+        if bal < amount {
+            panic!("Insufficient balance");
+        }
+        env.storage().persistent().set(&caller, &(bal - amount));
+    }
+}`,
+    checks: [
+      {
+        type: 'has_function',
+        name: 'withdraw',
+        params: ['env', 'caller', 'amount'],
+        message: "Missing 'withdraw' function",
+      },
+      {
+        type: 'contains_pattern',
+        pattern: 'require_auth()',
+        message: 'withdraw must call caller.require_auth()',
+        description: 'require_auth() in withdraw',
+      },
+      {
+        type: 'contains_pattern',
+        pattern: 'panic!',
+        message: 'Must panic when balance is insufficient',
+        description: 'panic! on underflow',
+      },
+      {
+        type: 'storage_operation',
+        operation: 'get',
+        message: 'Must read balance before subtracting',
+      },
+      {
+        type: 'storage_operation',
+        operation: 'set',
+        message: 'Must persist the updated balance',
+      },
+    ],
+    hints: [
+      'The first line of withdraw should be `caller.require_auth();`',
+      'Read the balance, then compare: `if bal < amount { panic!("Insufficient balance"); }`',
+      'Only update storage after both checks pass.',
+    ],
+    conceptsIntroduced: ['require_auth', 'balance check', 'authorization'],
+  },
+
+  {
+    id: 'storage-overflow',
+    title: 'Storage Overflow',
+    order: 2,
+    difficulty: 'beginner',
+    category: 'Integer Safety',
+    icon: '💥',
+    xpReward: 175,
+    description:
+      'A balance contract uses unchecked arithmetic. A deposit of a huge number can overflow and wrap around to a negative balance.',
+    objective:
+      'Guard against overflow by panicking when `amount <= 0` or when the new balance would exceed `i128::MAX`.',
+    vulnerableContract: `#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct BankContract;
+
+#[contractimpl]
+impl BankContract {
+    // 🐛 VULNERABILITY: No bounds check — negative or overflowing deposits accepted
+    pub fn deposit(env: Env, caller: Address, amount: i128) {
+        caller.require_auth();
+        let bal: i128 = env.storage().persistent().get(&caller).unwrap_or(0);
+        env.storage().persistent().set(&caller, &(bal + amount));
+    }
+
+    pub fn balance(env: Env, caller: Address) -> i128 {
+        env.storage().persistent().get(&caller).unwrap_or(0)
+    }
+}`,
+    template: `#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct BankContract;
+
+#[contractimpl]
+impl BankContract {
+    // TODO: Fix deposit
+    // 1. Panic if amount <= 0
+    // 2. Panic if bal + amount would overflow i128::MAX
+    //    Hint: use checked_add — if it returns None, panic
+    pub fn deposit(env: Env, caller: Address, amount: i128) {
+        caller.require_auth();
+        let bal: i128 = env.storage().persistent().get(&caller).unwrap_or(0);
+        env.storage().persistent().set(&caller, &(bal + amount));
+    }
+
+    pub fn balance(env: Env, caller: Address) -> i128 {
+        env.storage().persistent().get(&caller).unwrap_or(0)
+    }
+}`,
+    solution: `#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct BankContract;
+
+#[contractimpl]
+impl BankContract {
+    pub fn deposit(env: Env, caller: Address, amount: i128) {
+        caller.require_auth();
+        if amount <= 0 {
+            panic!("Amount must be positive");
+        }
+        let bal: i128 = env.storage().persistent().get(&caller).unwrap_or(0);
+        let new_bal = bal.checked_add(amount).expect("Overflow");
+        env.storage().persistent().set(&caller, &new_bal);
+    }
+
+    pub fn balance(env: Env, caller: Address) -> i128 {
+        env.storage().persistent().get(&caller).unwrap_or(0)
+    }
+}`,
+    checks: [
+      {
+        type: 'has_function',
+        name: 'deposit',
+        params: ['env', 'caller', 'amount'],
+        message: "Missing 'deposit' function",
+      },
+      {
+        type: 'contains_pattern',
+        pattern: 'panic!',
+        message: 'Must panic on invalid input',
+        description: 'panic! guard',
+      },
+      {
+        type: 'contains_pattern',
+        pattern: 'checked_add',
+        message: 'Use checked_add to prevent overflow',
+        description: 'checked_add usage',
+      },
+      {
+        type: 'storage_operation',
+        operation: 'set',
+        message: 'Must persist the new balance',
+      },
+    ],
+    hints: [
+      'First check: `if amount <= 0 { panic!("Amount must be positive"); }`',
+      'Use `bal.checked_add(amount).expect("Overflow")` instead of `bal + amount`',
+      'Store the result of checked_add, not the raw sum.',
+    ],
+    conceptsIntroduced: ['checked_add', 'integer overflow', 'input validation'],
+  },
+
+  {
+    id: 'access-control-bypass',
+    title: 'Access Control Bypass',
+    order: 3,
+    difficulty: 'intermediate',
+    category: 'Access Control',
+    icon: '🔓',
+    xpReward: 200,
+    description:
+      'An admin-only mint function checks the wrong address. Any caller can mint unlimited tokens.',
+    objective:
+      'Fix the admin check so it reads the stored admin and calls `require_auth()` on that address, not on the `to` address.',
+    vulnerableContract: `#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+const ADMIN: Symbol = symbol_short!("ADMIN");
+
+#[contract]
+pub struct TokenContract;
+
+#[contractimpl]
+impl TokenContract {
+    pub fn init(env: Env, admin: Address) {
+        env.storage().instance().set(&ADMIN, &admin);
+    }
+
+    // 🐛 VULNERABILITY: Checks auth on 'to' (the recipient) instead of admin!
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        to.require_auth();
+        let bal: i128 = env.storage().persistent().get(&to).unwrap_or(0);
+        env.storage().persistent().set(&to, &(bal + amount));
+    }
+
+    pub fn balance(env: Env, account: Address) -> i128 {
+        env.storage().persistent().get(&account).unwrap_or(0)
+    }
+}`,
+    template: `#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+const ADMIN: Symbol = symbol_short!("ADMIN");
+
+#[contract]
+pub struct TokenContract;
+
+#[contractimpl]
+impl TokenContract {
+    pub fn init(env: Env, admin: Address) {
+        env.storage().instance().set(&ADMIN, &admin);
+    }
+
+    // TODO: Fix mint
+    // 1. Load the admin address from storage
+    // 2. Call require_auth() on the admin (not on 'to')
+    // 3. Then update the recipient's balance
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        to.require_auth();
+        let bal: i128 = env.storage().persistent().get(&to).unwrap_or(0);
+        env.storage().persistent().set(&to, &(bal + amount));
+    }
+
+    pub fn balance(env: Env, account: Address) -> i128 {
+        env.storage().persistent().get(&account).unwrap_or(0)
+    }
+}`,
+    solution: `#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+const ADMIN: Symbol = symbol_short!("ADMIN");
+
+#[contract]
+pub struct TokenContract;
+
+#[contractimpl]
+impl TokenContract {
+    pub fn init(env: Env, admin: Address) {
+        env.storage().instance().set(&ADMIN, &admin);
+    }
+
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let admin: Address = env.storage().instance().get(&ADMIN).unwrap();
+        admin.require_auth();
+        let bal: i128 = env.storage().persistent().get(&to).unwrap_or(0);
+        env.storage().persistent().set(&to, &(bal + amount));
+    }
+
+    pub fn balance(env: Env, account: Address) -> i128 {
+        env.storage().persistent().get(&account).unwrap_or(0)
+    }
+}`,
+    checks: [
+      {
+        type: 'has_function',
+        name: 'mint',
+        params: ['env', 'to', 'amount'],
+        message: "Missing 'mint' function",
+      },
+      {
+        type: 'contains_pattern',
+        pattern: 'ADMIN',
+        message: 'Must load the ADMIN from storage',
+        description: 'ADMIN key usage',
+      },
+      {
+        type: 'storage_operation',
+        operation: 'get',
+        message: 'Must read admin from storage',
+      },
+      {
+        type: 'contains_pattern',
+        pattern: 'require_auth()',
+        message: 'Must call require_auth() on the admin address',
+        description: 'require_auth() on admin',
+      },
+      {
+        type: 'storage_operation',
+        operation: 'set',
+        message: 'Must update the recipient balance',
+      },
+    ],
+    hints: [
+      'Load admin: `let admin: Address = env.storage().instance().get(&ADMIN).unwrap();`',
+      'Then call `admin.require_auth();` — not `to.require_auth()`',
+      'After the auth check, update the balance for `to` as before.',
+    ],
+    conceptsIntroduced: ['admin pattern', 'wrong auth target', 'privilege escalation'],
+  },
+
+  {
+    id: 'front-running',
+    title: 'Front-Running Vulnerability',
+    order: 4,
+    difficulty: 'intermediate',
+    category: 'Timing',
+    icon: '⏱️',
+    xpReward: 225,
+    description:
+      'A price-sensitive swap contract reads the price at execution time with no deadline. An attacker can observe the transaction and front-run it.',
+    objective:
+      'Add a `deadline` parameter (ledger sequence) and panic if `env.ledger().sequence() > deadline`.',
+    vulnerableContract: `#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+const PRICE: Symbol = symbol_short!("PRICE");
+
+#[contract]
+pub struct SwapContract;
+
+#[contractimpl]
+impl SwapContract {
+    pub fn set_price(env: Env, admin: Address, price: i128) {
+        admin.require_auth();
+        env.storage().instance().set(&PRICE, &price);
+    }
+
+    // 🐛 VULNERABILITY: No deadline — transaction can be held and executed
+    // at an unfavorable price by a front-running validator.
+    pub fn swap(env: Env, caller: Address, amount: i128) -> i128 {
+        caller.require_auth();
+        let price: i128 = env.storage().instance().get(&PRICE).unwrap_or(1);
+        price * amount
+    }
+}`,
+    template: `#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+const PRICE: Symbol = symbol_short!("PRICE");
+
+#[contract]
+pub struct SwapContract;
+
+#[contractimpl]
+impl SwapContract {
+    pub fn set_price(env: Env, admin: Address, price: i128) {
+        admin.require_auth();
+        env.storage().instance().set(&PRICE, &price);
+    }
+
+    // TODO: Add a 'deadline: u32' parameter
+    // Panic with "Expired" if env.ledger().sequence() > deadline
+    pub fn swap(env: Env, caller: Address, amount: i128) -> i128 {
+        caller.require_auth();
+        let price: i128 = env.storage().instance().get(&PRICE).unwrap_or(1);
+        price * amount
+    }
+}`,
+    solution: `#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+const PRICE: Symbol = symbol_short!("PRICE");
+
+#[contract]
+pub struct SwapContract;
+
+#[contractimpl]
+impl SwapContract {
+    pub fn set_price(env: Env, admin: Address, price: i128) {
+        admin.require_auth();
+        env.storage().instance().set(&PRICE, &price);
+    }
+
+    pub fn swap(env: Env, caller: Address, amount: i128, deadline: u32) -> i128 {
+        caller.require_auth();
+        if env.ledger().sequence() > deadline {
+            panic!("Expired");
+        }
+        let price: i128 = env.storage().instance().get(&PRICE).unwrap_or(1);
+        price * amount
+    }
+}`,
+    checks: [
+      {
+        type: 'has_function',
+        name: 'swap',
+        params: ['env', 'caller', 'amount', 'deadline'],
+        message: "swap must include a 'deadline: u32' parameter",
+      },
+      {
+        type: 'contains_pattern',
+        pattern: 'ledger()',
+        message: 'Must check env.ledger().sequence()',
+        description: 'ledger().sequence() check',
+      },
+      {
+        type: 'contains_pattern',
+        pattern: 'deadline',
+        message: 'Must compare against the deadline',
+        description: 'deadline comparison',
+      },
+      {
+        type: 'contains_pattern',
+        pattern: 'panic!',
+        message: 'Must panic when the deadline is exceeded',
+        description: 'panic! on expiry',
+      },
+    ],
+    hints: [
+      'Add `deadline: u32` as the last parameter of swap.',
+      'Check: `if env.ledger().sequence() > deadline { panic!("Expired"); }`',
+      'Place the deadline check before reading the price.',
+    ],
+    conceptsIntroduced: ['front-running', 'deadline', 'ledger sequence', 'MEV'],
+  },
+
+  {
+    id: 'unchecked-inputs',
+    title: 'Unchecked Inputs',
+    order: 5,
+    difficulty: 'advanced',
+    category: 'Input Validation',
+    icon: '🧨',
+    xpReward: 250,
+    description:
+      'A transfer function accepts any amount — including zero and negative values — silently corrupting balances.',
+    objective:
+      'Validate that `amount > 0`, that the sender has sufficient balance, and that `from != to`.',
+    vulnerableContract: `#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct TransferContract;
+
+#[contractimpl]
+impl TransferContract {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let bal: i128 = env.storage().persistent().get(&to).unwrap_or(0);
+        env.storage().persistent().set(&to, &(bal + amount));
+    }
+
+    // 🐛 VULNERABILITIES:
+    // 1. No check that amount > 0
+    // 2. No check that from has enough balance
+    // 3. No check that from != to (self-transfer inflates nothing but wastes gas)
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        let from_bal: i128 = env.storage().persistent().get(&from).unwrap_or(0);
+        let to_bal: i128 = env.storage().persistent().get(&to).unwrap_or(0);
+        env.storage().persistent().set(&from, &(from_bal - amount));
+        env.storage().persistent().set(&to, &(to_bal + amount));
+    }
+}`,
+    template: `#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct TransferContract;
+
+#[contractimpl]
+impl TransferContract {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let bal: i128 = env.storage().persistent().get(&to).unwrap_or(0);
+        env.storage().persistent().set(&to, &(bal + amount));
+    }
+
+    // TODO: Fix transfer with three guards:
+    // 1. panic if amount <= 0
+    // 2. panic if from == to
+    // 3. panic if from_bal < amount
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        let from_bal: i128 = env.storage().persistent().get(&from).unwrap_or(0);
+        let to_bal: i128 = env.storage().persistent().get(&to).unwrap_or(0);
+        env.storage().persistent().set(&from, &(from_bal - amount));
+        env.storage().persistent().set(&to, &(to_bal + amount));
+    }
+}`,
+    solution: `#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct TransferContract;
+
+#[contractimpl]
+impl TransferContract {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let bal: i128 = env.storage().persistent().get(&to).unwrap_or(0);
+        env.storage().persistent().set(&to, &(bal + amount));
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        if amount <= 0 {
+            panic!("Amount must be positive");
+        }
+        if from == to {
+            panic!("Cannot transfer to self");
+        }
+        let from_bal: i128 = env.storage().persistent().get(&from).unwrap_or(0);
+        if from_bal < amount {
+            panic!("Insufficient balance");
+        }
+        let to_bal: i128 = env.storage().persistent().get(&to).unwrap_or(0);
+        env.storage().persistent().set(&from, &(from_bal - amount));
+        env.storage().persistent().set(&to, &(to_bal + amount));
+    }
+}`,
+    checks: [
+      {
+        type: 'has_function',
+        name: 'transfer',
+        params: ['env', 'from', 'to', 'amount'],
+        message: "Missing 'transfer' function",
+      },
+      {
+        type: 'contains_pattern',
+        pattern: 'amount <= 0',
+        message: 'Must check that amount > 0',
+        description: 'amount > 0 guard',
+      },
+      {
+        type: 'contains_pattern',
+        pattern: 'from == to',
+        message: 'Must check that from != to',
+        description: 'self-transfer guard',
+      },
+      {
+        type: 'contains_pattern',
+        pattern: 'from_bal < amount',
+        message: 'Must check sufficient balance',
+        description: 'balance sufficiency check',
+      },
+      {
+        type: 'contains_pattern',
+        pattern: 'panic!',
+        message: 'Must panic on invalid conditions',
+        description: 'panic! guards',
+      },
+      {
+        type: 'storage_operation',
+        operation: 'set',
+        message: 'Must update both balances',
+      },
+    ],
+    hints: [
+      'Add `if amount <= 0 { panic!("Amount must be positive"); }` right after require_auth.',
+      'Add `if from == to { panic!("Cannot transfer to self"); }`',
+      'Read from_bal first, then check `if from_bal < amount { panic!("Insufficient balance"); }`',
+    ],
+    conceptsIntroduced: ['input validation', 'self-transfer', 'balance guard', 'defensive programming'],
+  },
+];

--- a/src/index.css
+++ b/src/index.css
@@ -1998,3 +1998,413 @@ button {
     padding: 0 16px;
   }
 }
+
+/* ==========================================
+   CTF MODE STYLES
+   ========================================== */
+
+/* ── Page layout ── */
+.ctf-page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+.ctf-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.ctf-title {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 2rem;
+  color: var(--text-primary);
+  margin: 0 0 0.25rem;
+}
+
+.ctf-subtitle {
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.ctf-header-stats {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.ctf-stat {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.ctf-stat strong {
+  color: var(--cyan);
+}
+
+/* ── Challenge grid ── */
+.ctf-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.ctf-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  padding: 1.25rem;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s, transform 0.15s, box-shadow 0.2s;
+  width: 100%;
+}
+
+.ctf-card:hover {
+  border-color: var(--cyan);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 20px rgba(6, 214, 160, 0.15);
+}
+
+.ctf-card--active {
+  border-color: var(--cyan);
+  box-shadow: 0 0 0 2px rgba(6, 214, 160, 0.3);
+}
+
+.ctf-card--done {
+  border-color: var(--green, #06d6a0);
+}
+
+.ctf-card-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.ctf-card-icon {
+  font-size: 1.75rem;
+}
+
+.ctf-card-badge {
+  background: var(--cyan);
+  color: var(--bg-primary);
+  border-radius: 50%;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.ctf-card-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 0.4rem;
+}
+
+.ctf-difficulty {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 8px;
+  border-radius: 20px;
+}
+
+.ctf-difficulty--cyan  { background: rgba(6,214,160,0.15); color: var(--cyan); }
+.ctf-difficulty--gold  { background: rgba(255,190,11,0.15); color: #ffbe0b; }
+.ctf-difficulty--red   { background: rgba(239,71,111,0.15); color: #ef476f; }
+
+.ctf-card-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 0.6rem;
+}
+
+.ctf-card-category {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.ctf-card-xp {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--cyan);
+}
+
+/* ── Workspace split view ── */
+.ctf-workspace {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 900px) {
+  .ctf-workspace {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ctf-panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.ctf-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-secondary);
+}
+
+.ctf-panel-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.ctf-panel-tag {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+
+.ctf-panel-tag--danger  { background: rgba(239,71,111,0.2); color: #ef476f; }
+.ctf-panel-tag--success { background: rgba(6,214,160,0.2);  color: var(--cyan); }
+
+.ctf-description {
+  padding: 1rem;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.ctf-description p { margin: 0 0 0.5rem; }
+.ctf-description p:last-child { margin: 0; }
+
+.ctf-objective {
+  color: var(--text-primary) !important;
+}
+
+/* ── Action bar ── */
+.ctf-actions {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--border-subtle);
+  flex-wrap: wrap;
+}
+
+/* ── Terminal ── */
+.ctf-terminal {
+  background: #0d1117;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  padding: 0.75rem 1rem;
+  min-height: 120px;
+  max-height: 200px;
+  overflow-y: auto;
+  border-top: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+}
+
+.ctf-terminal-placeholder {
+  color: #555;
+}
+
+.ctf-terminal-line { margin-bottom: 2px; }
+.ctf-terminal-line--info    { color: #8b949e; }
+.ctf-terminal-line--pass    { color: #3fb950; }
+.ctf-terminal-line--fail    { color: #f85149; }
+.ctf-terminal-line--success { color: #58a6ff; font-weight: 600; }
+.ctf-terminal-line--xp      { color: #ffbe0b; }
+.ctf-terminal-line--badge   { color: #d2a8ff; }
+.ctf-terminal-line--hint    { color: #ffa657; }
+
+/* ── Intro Modal ── */
+.ctf-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.ctf-modal {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 16px;
+  padding: 2rem;
+  max-width: 520px;
+  width: 100%;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+}
+
+.ctf-modal-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.ctf-modal-icon {
+  font-size: 2rem;
+}
+
+.ctf-modal-header h2 {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 1.3rem;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.ctf-modal-body {
+  margin-bottom: 1.5rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.7;
+}
+
+.ctf-modal-body p { margin: 0 0 1rem; }
+
+.ctf-modal-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.ctf-modal-steps li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.ctf-step-num {
+  background: var(--cyan);
+  color: var(--bg-primary);
+  border-radius: 50%;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.ctf-modal-note {
+  background: rgba(6, 214, 160, 0.08);
+  border-left: 3px solid var(--cyan);
+  padding: 0.6rem 0.75rem;
+  border-radius: 0 6px 6px 0;
+  margin: 0 !important;
+}
+
+/* ── Home CTF section ── */
+.ctf-home-section {
+  padding: 5rem 1.5rem;
+  background: linear-gradient(135deg, rgba(6,214,160,0.05) 0%, rgba(131,56,236,0.05) 100%);
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.ctf-home-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 3rem;
+  align-items: center;
+}
+
+@media (max-width: 768px) {
+  .ctf-home-inner {
+    grid-template-columns: 1fr;
+  }
+}
+
+.ctf-home-eyebrow {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--cyan);
+  margin-bottom: 0.5rem;
+}
+
+.ctf-home-title {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 2rem;
+  color: var(--text-primary);
+  margin: 0 0 1rem;
+}
+
+.ctf-home-desc {
+  color: var(--text-secondary);
+  line-height: 1.7;
+  margin-bottom: 1.25rem;
+  max-width: 520px;
+}
+
+.ctf-home-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.ctf-home-badges {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ctf-home-badge-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  padding: 0.75rem 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  min-width: 180px;
+}
+
+.ctf-home-badge-icon {
+  font-size: 1.5rem;
+}

--- a/src/pages/CTFMode.jsx
+++ b/src/pages/CTFMode.jsx
@@ -1,0 +1,339 @@
+import React, { useState, useEffect, useRef } from 'react';
+import Editor from '@monaco-editor/react';
+import { ctfChallenges } from '../data/ctfChallenges';
+import { validateCode } from '../systems/codeValidator';
+import { loadProgress, saveProgress } from '../systems/storage';
+import { completeCTF } from '../systems/gameEngine';
+
+const CTF_INTRO_KEY = 'soroban_quest_ctf_intro_seen';
+
+/* ── helpers ── */
+function delay(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function runCTFTests(code, challenge) {
+  const results = [];
+
+  // Phase 1: basic syntax
+  const trimmed = code.trim();
+  if (!trimmed) {
+    return {
+      results: [{ passed: false, message: '✗ Editor is empty — write your fix!' }],
+      allPassed: false,
+    };
+  }
+  let braces = 0;
+  for (const ch of trimmed) {
+    if (ch === '{') braces++;
+    if (ch === '}') braces--;
+  }
+  results.push(
+    braces === 0
+      ? { passed: true, message: '✓ Syntax looks good' }
+      : { passed: false, message: '✗ Unbalanced braces' }
+  );
+  await delay(250);
+
+  // Phase 2: challenge checks
+  const validation = validateCode(code, challenge.checks);
+  for (const r of validation.results) {
+    await delay(180);
+    results.push(r);
+  }
+
+  const allPassed = results.every((r) => r.passed);
+  return { results, allPassed };
+}
+
+/* ── Intro Modal ── */
+function IntroModal({ onClose }) {
+  return (
+    <div className="ctf-modal-backdrop" onClick={onClose}>
+      <div className="ctf-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="ctf-modal-header">
+          <span className="ctf-modal-icon">🚩</span>
+          <h2>How CTF Mode Works</h2>
+        </div>
+        <div className="ctf-modal-body">
+          <p>
+            <strong>CTF (Capture The Flag)</strong> challenges teach smart-contract security by
+            showing you intentionally vulnerable Soroban contracts.
+          </p>
+          <ol className="ctf-modal-steps">
+            <li>
+              <span className="ctf-step-num">1</span>
+              <span>
+                <strong>Read the vulnerable contract</strong> on the left panel. Spot the bug.
+              </span>
+            </li>
+            <li>
+              <span className="ctf-step-num">2</span>
+              <span>
+                <strong>Write the fix</strong> in the editor on the right. The template gives you a
+                starting point.
+              </span>
+            </li>
+            <li>
+              <span className="ctf-step-num">3</span>
+              <span>
+                <strong>Run the exploit checks</strong> to verify your solution is correct.
+              </span>
+            </li>
+            <li>
+              <span className="ctf-step-num">4</span>
+              <span>
+                <strong>Earn XP and CTF badges</strong> separate from the main quest progression.
+              </span>
+            </li>
+          </ol>
+          <p className="ctf-modal-note">
+            💡 Use hints if you're stuck. Revealing the solution is always available for learning.
+          </p>
+        </div>
+        <button className="btn btn-primary" onClick={onClose}>
+          Let's Hunt Bugs 🐛
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ── Challenge Card ── */
+function ChallengeCard({ challenge, completed, active, onClick }) {
+  const diffColor = { beginner: 'cyan', intermediate: 'gold', advanced: 'red' };
+  return (
+    <button
+      className={`ctf-card ${active ? 'ctf-card--active' : ''} ${completed ? 'ctf-card--done' : ''}`}
+      onClick={onClick}
+    >
+      <div className="ctf-card-top">
+        <span className="ctf-card-icon">{challenge.icon}</span>
+        {completed && <span className="ctf-card-badge">✓</span>}
+      </div>
+      <h3 className="ctf-card-title">{challenge.title}</h3>
+      <span className={`ctf-difficulty ctf-difficulty--${diffColor[challenge.difficulty]}`}>
+        {challenge.difficulty}
+      </span>
+      <div className="ctf-card-meta">
+        <span className="ctf-card-category">{challenge.category}</span>
+        <span className="ctf-card-xp">+{challenge.xpReward} XP</span>
+      </div>
+    </button>
+  );
+}
+
+/* ── Main Page ── */
+export default function CTFMode() {
+  const [showIntro, setShowIntro] = useState(() => !localStorage.getItem(CTF_INTRO_KEY));
+  const [selected, setSelected] = useState(ctfChallenges[0]);
+  const [code, setCode] = useState(ctfChallenges[0].template);
+  const [termLines, setTermLines] = useState([]);
+  const [running, setRunning] = useState(false);
+  const [showSolution, setShowSolution] = useState(false);
+  const [hintIndex, setHintIndex] = useState(0);
+  const [gameState, setGameState] = useState(() => loadProgress());
+  const termRef = useRef(null);
+
+  const completedCTFs = gameState.completedCTFs || [];
+
+  // Scroll terminal to bottom
+  useEffect(() => {
+    if (termRef.current) termRef.current.scrollTop = termRef.current.scrollHeight;
+  }, [termLines]);
+
+  function selectChallenge(ch) {
+    setSelected(ch);
+    setCode(ch.template);
+    setTermLines([]);
+    setShowSolution(false);
+    setHintIndex(0);
+  }
+
+  function closeIntro() {
+    localStorage.setItem(CTF_INTRO_KEY, '1');
+    setShowIntro(false);
+  }
+
+  async function handleRun() {
+    if (running) return;
+    setRunning(true);
+    setTermLines([{ text: `> Running exploit checks for "${selected.title}"…`, type: 'info' }]);
+
+    const { results, allPassed } = await runCTFTests(code, selected);
+
+    const lines = [{ text: `> Running exploit checks for "${selected.title}"…`, type: 'info' }];
+    for (const r of results) {
+      lines.push({ text: r.message, type: r.passed ? 'pass' : 'fail' });
+    }
+
+    if (allPassed) {
+      lines.push({ text: '', type: 'info' });
+      lines.push({ text: '🎉 Vulnerability patched! Challenge complete!', type: 'success' });
+
+      if (!completedCTFs.includes(selected.id)) {
+        const newState = completeCTF(gameState, selected.id, selected.xpReward);
+        saveProgress(newState);
+        setGameState(newState);
+        lines.push({ text: `+${selected.xpReward} XP earned`, type: 'xp' });
+        if (newState.newBadges?.length) {
+          for (const b of newState.newBadges) {
+            lines.push({ text: `🏅 Badge unlocked: ${b}`, type: 'badge' });
+          }
+        }
+      } else {
+        lines.push({ text: '(Already completed — no XP awarded)', type: 'info' });
+      }
+    } else {
+      const passed = results.filter((r) => r.passed).length;
+      lines.push({
+        text: `❌ ${passed}/${results.length} checks passed. Keep digging!`,
+        type: 'fail',
+      });
+    }
+
+    setTermLines(lines);
+    setRunning(false);
+  }
+
+  function handleHint() {
+    if (hintIndex < selected.hints.length) {
+      setTermLines((prev) => [
+        ...prev,
+        { text: `💡 Hint ${hintIndex + 1}: ${selected.hints[hintIndex]}`, type: 'hint' },
+      ]);
+      setHintIndex((i) => i + 1);
+    }
+  }
+
+  function handleReveal() {
+    setShowSolution((s) => !s);
+    setCode(showSolution ? selected.template : selected.solution);
+  }
+
+  const theme = localStorage.getItem('soroban_quest_theme') === 'light' ? 'light' : 'vs-dark';
+
+  return (
+    <div className="ctf-page">
+      {showIntro && <IntroModal onClose={closeIntro} />}
+
+      {/* Header */}
+      <div className="ctf-header">
+        <div>
+          <h1 className="ctf-title">🚩 CTF Mode</h1>
+          <p className="ctf-subtitle">
+            Find and fix vulnerabilities in intentionally broken Soroban contracts.
+          </p>
+        </div>
+        <div className="ctf-header-stats">
+          <span className="ctf-stat">
+            <strong>{completedCTFs.length}</strong> / {ctfChallenges.length} solved
+          </span>
+          <button className="btn btn-ghost btn-sm" onClick={() => setShowIntro(true)}>
+            ❓ How it works
+          </button>
+        </div>
+      </div>
+
+      {/* Challenge grid */}
+      <div className="ctf-grid">
+        {ctfChallenges.map((ch) => (
+          <ChallengeCard
+            key={ch.id}
+            challenge={ch}
+            completed={completedCTFs.includes(ch.id)}
+            active={selected.id === ch.id}
+            onClick={() => selectChallenge(ch)}
+          />
+        ))}
+      </div>
+
+      {/* Split view */}
+      <div className="ctf-workspace">
+        {/* Left: vulnerable contract (read-only) */}
+        <div className="ctf-panel ctf-panel--left">
+          <div className="ctf-panel-header">
+            <span className="ctf-panel-label">🐛 Vulnerable Contract</span>
+            <span className="ctf-panel-tag ctf-panel-tag--danger">READ ONLY</span>
+          </div>
+          <div className="ctf-description">
+            <p>{selected.description}</p>
+            <p className="ctf-objective">
+              <strong>Objective:</strong> {selected.objective}
+            </p>
+          </div>
+          <Editor
+            height="380px"
+            language="rust"
+            value={selected.vulnerableContract}
+            theme={theme}
+            options={{
+              readOnly: true,
+              minimap: { enabled: false },
+              fontSize: 13,
+              lineNumbers: 'on',
+              scrollBeyondLastLine: false,
+              wordWrap: 'on',
+            }}
+          />
+        </div>
+
+        {/* Right: exploit editor */}
+        <div className="ctf-panel ctf-panel--right">
+          <div className="ctf-panel-header">
+            <span className="ctf-panel-label">⚔️ Your Fix</span>
+            {completedCTFs.includes(selected.id) && (
+              <span className="ctf-panel-tag ctf-panel-tag--success">SOLVED ✓</span>
+            )}
+          </div>
+          <Editor
+            height="380px"
+            language="rust"
+            value={code}
+            onChange={(v) => setCode(v || '')}
+            theme={theme}
+            options={{
+              minimap: { enabled: false },
+              fontSize: 13,
+              lineNumbers: 'on',
+              scrollBeyondLastLine: false,
+              wordWrap: 'on',
+            }}
+          />
+
+          {/* Action bar */}
+          <div className="ctf-actions">
+            <button className="btn btn-primary" onClick={handleRun} disabled={running}>
+              {running ? '⏳ Checking…' : '▶ Run Checks'}
+            </button>
+            <button
+              className="btn btn-secondary"
+              onClick={handleHint}
+              disabled={hintIndex >= selected.hints.length}
+            >
+              💡 Hint ({selected.hints.length - hintIndex} left)
+            </button>
+            <button className="btn btn-ghost btn-sm" onClick={handleReveal}>
+              {showSolution ? '🙈 Hide Solution' : '👁 Show Solution'}
+            </button>
+          </div>
+
+          {/* Terminal */}
+          <div className="ctf-terminal" ref={termRef}>
+            {termLines.length === 0 ? (
+              <span className="ctf-terminal-placeholder">
+                Press "Run Checks" to validate your fix…
+              </span>
+            ) : (
+              termLines.map((line, i) => (
+                <div key={i} className={`ctf-terminal-line ctf-terminal-line--${line.type}`}>
+                  {line.text}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -178,6 +178,44 @@ export default function Home() {
                     </div>
                 </div>
             </section>
+
+            <section className="ctf-home-section">
+                <div className="ctf-home-inner">
+                    <div className="ctf-home-text">
+                        <div className="ctf-home-eyebrow">🚩 New Mode</div>
+                        <h2 className="ctf-home-title">CTF Security Challenges</h2>
+                        <p className="ctf-home-desc">
+                            Think like an attacker. Each CTF challenge presents an intentionally
+                            vulnerable Soroban contract — your job is to find the bug and write
+                            the fix. Earn separate XP and exclusive security badges.
+                        </p>
+                        <ul className="ctf-home-list">
+                            <li>🔄 Reentrancy exploits</li>
+                            <li>💥 Integer overflow / underflow</li>
+                            <li>🔓 Access control bypass</li>
+                            <li>⏱️ Front-running vulnerabilities</li>
+                            <li>🧨 Unchecked input attacks</li>
+                        </ul>
+                        <button className="btn btn-primary btn-lg" onClick={() => navigate('/ctf')}>
+                            🚩 Enter CTF Mode
+                        </button>
+                    </div>
+                    <div className="ctf-home-badges">
+                        <div className="ctf-home-badge-card">
+                            <span className="ctf-home-badge-icon">🩸</span>
+                            <span>First Blood</span>
+                        </div>
+                        <div className="ctf-home-badge-card">
+                            <span className="ctf-home-badge-icon">🎯</span>
+                            <span>Exploit Hunter</span>
+                        </div>
+                        <div className="ctf-home-badge-card">
+                            <span className="ctf-home-badge-icon">🔐</span>
+                            <span>Security Master</span>
+                        </div>
+                    </div>
+                </div>
+            </section>
         </div>
     );
 }

--- a/src/systems/gameEngine.js
+++ b/src/systems/gameEngine.js
@@ -76,6 +76,31 @@ export const BADGES = [
     icon: "⚡",
     condition: (state) => state.firstTryMissions?.length >= 1,
   },
+  // CTF badges
+  {
+    id: "ctf_first_blood",
+    name: "First Blood",
+    description: "Solve your first CTF challenge",
+    icon: "🩸",
+    category: "ctf",
+    condition: (state) => (state.completedCTFs || []).length >= 1,
+  },
+  {
+    id: "ctf_triple",
+    name: "Exploit Hunter",
+    description: "Solve 3 CTF challenges",
+    icon: "🎯",
+    category: "ctf",
+    condition: (state) => (state.completedCTFs || []).length >= 3,
+  },
+  {
+    id: "ctf_master",
+    name: "Security Master",
+    description: "Solve all 5 CTF challenges",
+    icon: "🔐",
+    category: "ctf",
+    condition: (state) => (state.completedCTFs || []).length >= 5,
+  },
 ];
 
 function getDefaultState() {
@@ -83,6 +108,7 @@ function getDefaultState() {
     xp: 0,
     level: 1,
     completedMissions: [],
+    completedCTFs: [],
     badges: [],
     firstTryMissions: [],
     currentMission: null,
@@ -156,6 +182,19 @@ export function completeMission(state, missionId, xpReward) {
   newState = awardXP(newState, xpReward);
   newState = checkBadges(newState);
 
+  return newState;
+}
+
+export function completeCTF(state, challengeId, xpReward) {
+  if ((state.completedCTFs || []).includes(challengeId)) {
+    return { ...state, alreadyCompleted: true };
+  }
+  let newState = {
+    ...state,
+    completedCTFs: [...(state.completedCTFs || []), challengeId],
+  };
+  newState = awardXP(newState, xpReward);
+  newState = checkBadges(newState);
   return newState;
 }
 


### PR DESCRIPTION
pr closes #67 

- Add 5 CTF challenges (reentrancy, overflow, access control, front-running, unchecked inputs)
- Add CTFMode page with split view, terminal output, hints, and solution reveal
- Add completeCTF() and 3 CTF badges to gameEngine
- Add /ctf route, navbar link, and home promo section
- Add CTF-specific CSS styles

## What does this PR do?
Describe the changes in this pull request.

## Related issue
Closes #

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Content (new mission or educational material)
- [ ] Documentation
- [ ] Refactor

## Testing checklist
- [ ] `npm run build` passes
- [ ] `npm run lint` passes (if available)
- [ ] Tested locally in the browser
- [ ] All existing pages still work correctly
- [ ] Screenshots attached (if UI change)

## Screenshots
If applicable, add screenshots of your changes.
