### PR TITLE
feat: add dynamic document titles per route (#92)

### DIFF
--- a/src/pages/Campaigns.jsx
+++ b/src/pages/Campaigns.jsx
@@ -7,8 +7,10 @@ import { loadProgress } from "../systems/storage.js";
 import { isMissionUnlocked } from "../systems/missionLoader.js";
 
 import "./Campaigns.css";
+import useDocumentTitle from '../systems/useDocumentTitle';
 
 export default function Campaigns() {
+  useDocumentTitle('Campaigns');
   const [progress, setProgress] = useState(loadProgress());
   const [selectedCampaign, setSelectedCampaign] = useState(null);
   const [showLoreModal, setShowLoreModal] = useState(false);

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,8 +2,10 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { loadProgress } from '../systems/storage';
 import { getAllMissions, isMissionUnlocked } from '../systems/missionLoader';
+import useDocumentTitle from '../systems/useDocumentTitle';
 
 export default function Home() {
+    useDocumentTitle('Home');
     const navigate = useNavigate();
     const state = loadProgress();
     const canvasRef = useRef(null);

--- a/src/pages/Journal.jsx
+++ b/src/pages/Journal.jsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo } from "react";
 import { getActivityLog, ACTIVITY_TYPES, clearLog } from "../systems/activityLogger";
 import { loadProgress } from "../systems/storage";
 import "./Journal.css";
+import useDocumentTitle from '../systems/useDocumentTitle';
 
 const EVENT_CONFIG = {
   [ACTIVITY_TYPES.MISSION_STARTED]: { icon: "⚔️", class: "mission", label: "Mission" },
@@ -15,6 +16,7 @@ const EVENT_CONFIG = {
 };
 
 export default function Journal() {
+  useDocumentTitle('Journal');
   const [log, setLog] = useState(() => getActivityLog());
   const [filter, setFilter] = useState("ALL");
   const progress = loadProgress();

--- a/src/pages/MissionDetail.jsx
+++ b/src/pages/MissionDetail.jsx
@@ -14,11 +14,13 @@ import { useToast } from "../systems/ToastContext";
 import { MissionErrorBoundary } from "../components/ErrorBoundary";
 import CodeReplayPlayer from "../components/CodeReplayPlayer";
 import CodeRecorder from "../systems/codeRecorder";
+import useDocumentTitle from '../systems/useDocumentTitle';
 
 // ─── Monaco marker model name (must be consistent across calls) ──────────────
 const LIVE_MARKER_OWNER = "soroban-quest-live";
 
 export default function MissionDetail() {
+  useDocumentTitle('Mission Detail');
   const { missionId } = useParams();
   const navigate = useNavigate();
   const mission = getMissionById(missionId);

--- a/src/pages/MissionMap.jsx
+++ b/src/pages/MissionMap.jsx
@@ -2,8 +2,10 @@ import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { loadProgress } from '../systems/storage';
 import { getAllMissions, isMissionUnlocked } from '../systems/missionLoader';
+import useDocumentTitle from '../systems/useDocumentTitle';
 
 export default function MissionMap() {
+    useDocumentTitle('Mission Map');
     const navigate = useNavigate();
     const state = loadProgress();
     const missions = getAllMissions();

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -13,8 +13,10 @@ import { getXPProgress, getRankTitle, BADGES } from "../systems/gameEngine";
 import { getAllMissions } from "../systems/missionLoader";
 import { avatars } from "../data/avatars";
 import { logActivity, ACTIVITY_TYPES } from "../systems/activityLogger";
+import useDocumentTitle from '../systems/useDocumentTitle';
 
 export default function Profile() {
+  useDocumentTitle('Profile');
   const [state, setState] = useState(loadProgress());
 
   // ✅ IMPORTANT: safe profile init

--- a/src/pages/SkillTree.jsx
+++ b/src/pages/SkillTree.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { missions } from '../data/missions';
 import { loadProgress } from '../systems/storage';
 import './SkillTree.css';
+import useDocumentTitle from '../systems/useDocumentTitle';
 
 const conceptCategories = {
   Core: {
@@ -32,6 +33,7 @@ const conceptCategories = {
 };
 
 export default function SkillTree() {
+  useDocumentTitle('Skill Tree');
   const [completedMissions, setCompletedMissions] = useState([]);
   const [selectedConcept, setSelectedConcept] = useState(null);
   const [hoveredConcept, setHoveredConcept] = useState(null);

--- a/src/systems/useDocumentTitle.js
+++ b/src/systems/useDocumentTitle.js
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+const BASE_TITLE = 'Soroban Quest';
+
+/**
+ * Custom hook to dynamically update the document title per route.
+ *
+ * @param {string} title - Page-specific title (e.g. "Profile", "Mission Map").
+ * @returns {void}
+ *
+ * Usage:
+ *   function Profile() {
+ *     useDocumentTitle('Profile');
+ *     return <div>...</div>;
+ *   }
+ *
+ * Renders as: "Profile | Soroban Quest"
+ */
+export default function useDocumentTitle(title) {
+    useEffect(() => {
+        if (!title) {
+            document.title = BASE_TITLE;
+            return;
+        }
+        const fullTitle = `${title} | ${BASE_TITLE}`;
+        if (document.title !== fullTitle) {
+            document.title = fullTitle;
+        }
+    }, [title]);
+}


### PR DESCRIPTION
Closes #92

Adds a reusable `useDocumentTitle()` custom hook and integrates it into all page components.

**Changes:**

- New file: `src/systems/useDocumentTitle.js` -- React custom hook that sets `document.title` to `{page} | Soroban Quest`
- Updated all page components to use the hook:
  - `Home.jsx` -> "Home | Soroban Quest"
  - `MissionMap.jsx` -> "Mission Map | Soroban Quest"
  - `MissionDetail.jsx` -> "Mission Detail | Soroban Quest"
  - `Profile.jsx` -> "Profile | Soroban Quest"
  - `Campaigns.jsx` -> "Campaigns | Soroban Quest"
  - `Journal.jsx` -> "Journal | Soroban Quest"
  - `SkillTree.jsx` -> "Skill Tree | Soroban Quest"

**Behavior:**
- Title updates immediately on navigation (via `useEffect`)
- Falls back to base title "Soroban Quest" if no page title is provided
- No re-renders -- only updates `document.title` when the value changes