### PR TITLE
fix: replace <a> tags with <Link> in Footer

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 
 export default function Footer() {
   return (
@@ -7,27 +8,26 @@ export default function Footer() {
         <div className="footer-section">
           <h4>Platform</h4>
           <ul>
-            <li><a href="/">Home</a></li>
-            <li><a href="/missions">Missions</a></li>
-            <li><a href="/profile">Profile</a></li>
-            <li><a href="/glossary">Glossary</a></li>
+            <li><Link to="/">Home</Link></li>
+            <li><Link to="/missions">Missions</Link></li>
+            <li><Link to="/profile">Profile</Link></li>
           </ul>
         </div>
 
         <div className="footer-section">
           <h4>Resources</h4>
           <ul>
-            <li><a href="https://soroban.stellar.org" target="_blank" rel="noopener">Soroban Docs</a></li>
-            <li><a href="https://stellar.org/developers" target="_blank" rel="noopener">Stellar SDK</a></li>
-            <li><a href="https://github.com/JafetCHVDev/soroban-quest" target="_blank" rel="noopener">GitHub</a></li>
+            <li><a href="https://soroban.stellar.org" target="_blank" rel="noopener noreferrer">Soroban Docs</a></li>
+            <li><a href="https://stellar.org/developers" target="_blank" rel="noopener noreferrer">Stellar SDK</a></li>
+            <li><a href="https://github.com/JafetCHVDev/soroban-quest" target="_blank" rel="noopener noreferrer">GitHub</a></li>
           </ul>
         </div>
 
         <div className="footer-section">
           <h4>Community</h4>
           <ul>
-            <li><a href="#" target="_blank" rel="noopener">Discord</a></li>
-            <li><a href="#" target="_blank" rel="noopener">Telegram</a></li>
+            <li><a href="#" target="_blank" rel="noopener noreferrer">Discord</a></li>
+            <li><a href="#" target="_blank" rel="noopener noreferrer">Telegram</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## What
Replaced raw <a> tags with React Router <Link> in Footer for client-side navigation. Removed broken /glossary link.

## Why
Internal links using <a> cause full page reloads and lose in-memory state in SPA.

## How
- Imported Link from react-router-dom
- Replaced <a href='/'> with <Link to='/'> for internal routes (Home, Missions, Profile)
- Removed broken /glossary link (page does not exist)
- Kept external links as <a> with target='_blank' and rel='noopener noreferrer'

## Testing
- Verified no full page reloads on footer link clicks