### PR TITLE
feat: implement scroll-to-top on route navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import Campaigns from "./pages/Campaigns";
 import SkillTree from "./pages/SkillTree";
 
 import Footer from "./components/Footer";
+import ScrollToTop from "./components/ScrollToTop";
 import NotFound from "./pages/NotFound";
 
 // 1. Import the ErrorBoundary
@@ -41,6 +42,7 @@ export default function App() {
     <ErrorBoundary>
       {/* 3. Wraped everything in ToastProvider */}
       <ToastProvider>
+        <ScrollToTop />
         <div className="app">
           <Navbar />
           <main className="main-content">

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## What
Added ScrollToTop component that automatically scrolls to top on route navigation.

## Why
Users were landing in the middle of pages after navigating, since scroll position was preserved.

## How
- Created src/components/ScrollToTop.jsx using useLocation and useEffect
- Mounted it inside Router in App.jsx before Routes
- Uses smooth scroll behavior

## Testing
- Verified scroll resets to top across all pages and back/forward navigation