### PR TITLE
fix: toast notification progress bar animation and exit transition

### DIFF
--- a/src/systems/Toast.css
+++ b/src/systems/Toast.css
@@ -47,6 +47,17 @@
   }
 }
 
+@keyframes slideOut {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+}
+
 .toast-content {
   display: flex;
   align-items: center;
@@ -63,7 +74,11 @@
   background: rgba(255, 255, 255, 0.2);
   width: 100%;
   transform-origin: left;
-  animation: shrink linear forwards;
+  animation: shrink 3s linear forwards;
+}
+
+.toast-leaving {
+  animation: slideOut 0.3s ease-out forwards;
 }
 
 @keyframes shrink {

--- a/src/systems/ToastContext.jsx
+++ b/src/systems/ToastContext.jsx
@@ -1,9 +1,23 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
 
 const ToastContext = createContext(null);
+const TOAST_DURATION = 3000;
 
 export const ToastProvider = ({ children }) => {
   const [toasts, setToasts] = useState([]);
+  const [leaving, setLeaving] = useState(new Set());
+
+  const dismissToast = useCallback((id) => {
+    setLeaving((prev) => new Set(prev).add(id));
+    setTimeout(() => {
+      setLeaving((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+      setToasts((prev) => (prev || []).filter((t) => t.id !== id));
+    }, 300);
+  }, []);
 
   const showToast = useCallback((message, type = 'info') => {
     const id = Date.now();
@@ -11,29 +25,27 @@ export const ToastProvider = ({ children }) => {
     
     setToasts((prev) => [...(prev || []), newToast]);
 
-    // Auto-remove after 3 seconds
     setTimeout(() => {
-      setToasts((prev) => (prev || []).filter((t) => t.id !== id));
-    }, 3000);
-  }, []);
+      dismissToast(id);
+    }, TOAST_DURATION);
+  }, [dismissToast]);
 
-  const removeToast = (id) => {
-    setToasts((prev) => (prev || []).filter((t) => t.id !== id));
-  };
+  const removeToast = useCallback((id) => {
+    dismissToast(id);
+  }, [dismissToast]);
 
   return (
     <ToastContext.Provider value={{ showToast }}>
       {children}
-      {/* The Toast Container */}
       <div className="toast-container">
         {(toasts || []).map((toast) => (
           <div 
             key={toast.id} 
-            className={`toast toast-${toast.type}`}
+            className={`toast toast-${toast.type}${leaving.has(toast.id) ? ' toast-leaving' : ''}`}
             onClick={() => removeToast(toast.id)}
           >
             <div className="toast-content">{toast.message}</div>
-            <div className="toast-progress" />
+            {!leaving.has(toast.id) && <div className="toast-progress" />}
           </div>
         ))}
       </div>


### PR DESCRIPTION
## What
Fixed toast progress bar animation and added smooth exit transitions.

## Why
Progress bar had no animation duration (defaulted to 0s), and toasts vanished instantly instead of fading out.

## How
- Set animation-duration: 3s on progress bar, matching the auto-dismiss timeout
- Added slideOut exit animation (opacity fade + translateX)
- Tracked leaving state to animate before DOM removal
- Extracted TOAST_DURATION as shared constant
- Hide progress bar during exit animation

## Testing
- Verified progress bar shrinks smoothly over 3s
- Verified exit animation plays before removal
- Tested across success, error, warning, info types