### PR TITLE
Add dynamic document titles per route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1315,7 +1314,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1326,7 +1324,8 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -1522,7 +1521,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1698,6 +1696,7 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -2047,6 +2046,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -2748,7 +2748,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2800,7 +2799,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2813,7 +2811,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3283,7 +3280,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/src/pages/Campaigns.jsx
+++ b/src/pages/Campaigns.jsx
@@ -5,6 +5,7 @@ import { missions } from "../data/missions.js";
 import { campaigns, getCampaignProgress } from "../data/campaigns.js";
 import { loadProgress } from "../systems/storage.js";
 import { isMissionUnlocked } from "../systems/missionLoader.js";
+import { useDocumentTitle } from "../systems/useDocumentTitle";
 
 import "./Campaigns.css";
 
@@ -13,6 +14,8 @@ export default function Campaigns() {
   const [selectedCampaign, setSelectedCampaign] = useState(null);
   const [showLoreModal, setShowLoreModal] = useState(false);
   const [firstVisit, setFirstVisit] = useState(false);
+
+  useDocumentTitle("Campaigns");
 
   useEffect(() => {
     // Listen for storage changes (profile updates)
@@ -161,7 +164,9 @@ export default function Campaigns() {
                   >
                     <div className="mission-order">#{mission.order}</div>
                     <div className="mission-title">{mission.title}</div>
-                    <div className={`mission-badge badge-${mission.difficulty}`}>
+                    <div
+                      className={`mission-badge badge-${mission.difficulty}`}
+                    >
                       {mission.difficulty}
                     </div>
                     {missionCompleted ? (

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,183 +1,206 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { loadProgress } from '../systems/storage';
-import { getAllMissions, isMissionUnlocked } from '../systems/missionLoader';
+import React, { useEffect, useRef, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { loadProgress } from "../systems/storage";
+import { getAllMissions, isMissionUnlocked } from "../systems/missionLoader";
+import { useDocumentTitle } from "../systems/useDocumentTitle";
 
 export default function Home() {
-    const navigate = useNavigate();
-    const state = loadProgress();
-    const canvasRef = useRef(null);
-    const missions = getAllMissions();
-    const completedCount = state.completedMissions.length;
-    const hasMissions = completedCount > 0;
+  const navigate = useNavigate();
+  const state = loadProgress();
+  const canvasRef = useRef(null);
+  const missions = getAllMissions();
+  const completedCount = state.completedMissions.length;
+  const hasMissions = completedCount > 0;
 
-    // Particle starfield effect
-    useEffect(() => {
-        const canvas = canvasRef.current;
-        if (!canvas) return;
-        const ctx = canvas.getContext('2d');
-        let animId;
+  useDocumentTitle("Home");
 
-        const resize = () => {
-            canvas.width = canvas.offsetWidth;
-            canvas.height = canvas.offsetHeight;
-        };
-        resize();
-        window.addEventListener('resize', resize);
+  // Particle starfield effect
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    let animId;
 
-        const stars = Array.from({ length: 120 }, () => ({
-            x: Math.random() * canvas.width,
-            y: Math.random() * canvas.height,
-            r: Math.random() * 1.5 + 0.3,
-            speed: Math.random() * 0.3 + 0.05,
-            opacity: Math.random() * 0.7 + 0.3,
-            pulse: Math.random() * Math.PI * 2,
-        }));
+    const resize = () => {
+      canvas.width = canvas.offsetWidth;
+      canvas.height = canvas.offsetHeight;
+    };
+    resize();
+    window.addEventListener("resize", resize);
 
-        function draw() {
-            ctx.clearRect(0, 0, canvas.width, canvas.height);
-            for (const s of stars) {
-                s.pulse += 0.02;
-                s.y -= s.speed;
-                if (s.y < -2) {
-                    s.y = canvas.height + 2;
-                    s.x = Math.random() * canvas.width;
-                }
-                const o = s.opacity * (0.6 + 0.4 * Math.sin(s.pulse));
-                ctx.beginPath();
-                ctx.arc(s.x, s.y, s.r, 0, Math.PI * 2);
-                ctx.fillStyle = `rgba(6, 214, 160, ${o})`;
-                ctx.fill();
-            }
-            animId = requestAnimationFrame(draw);
+    const stars = Array.from({ length: 120 }, () => ({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      r: Math.random() * 1.5 + 0.3,
+      speed: Math.random() * 0.3 + 0.05,
+      opacity: Math.random() * 0.7 + 0.3,
+      pulse: Math.random() * Math.PI * 2,
+    }));
+
+    function draw() {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      for (const s of stars) {
+        s.pulse += 0.02;
+        s.y -= s.speed;
+        if (s.y < -2) {
+          s.y = canvas.height + 2;
+          s.x = Math.random() * canvas.width;
         }
-        draw();
-        return () => {
-            cancelAnimationFrame(animId);
-            window.removeEventListener('resize', resize);
-        };
-    }, []);
+        const o = s.opacity * (0.6 + 0.4 * Math.sin(s.pulse));
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, s.r, 0, Math.PI * 2);
+        ctx.fillStyle = `rgba(6, 214, 160, ${o})`;
+        ctx.fill();
+      }
+      animId = requestAnimationFrame(draw);
+    }
+    draw();
+    return () => {
+      cancelAnimationFrame(animId);
+      window.removeEventListener("resize", resize);
+    };
+  }, []);
 
-    return (
-        <div>
-            <section className="hero">
-                <canvas ref={canvasRef} className="hero-particles" />
+  return (
+    <div>
+      <section className="hero">
+        <canvas ref={canvasRef} className="hero-particles" />
 
-                <div className="hero-badge">
-                    ✨ Zero setup • No wallet needed • Open source
-                </div>
-
-                <h1 className="hero-title">
-                    Master <span className="hero-title-gradient">Soroban</span>
-                    <br />Smart Contracts
-                </h1>
-
-                <p className="hero-subtitle">
-                    Embark on an epic quest to learn Stellar's smart contract platform.
-                    Write real Soroban code in your browser, solve challenges, and level up
-                    your blockchain skills — no installation required.
-                </p>
-
-                <div className="hero-actions">
-                    {hasMissions ? (
-                        <>
-                            <button className="btn btn-primary btn-lg" onClick={() => navigate('/missions')}>
-                                ⚔️ Continue Quest
-                            </button>
-                            <button className="btn btn-secondary btn-lg" onClick={() => navigate('/profile')}>
-                                📊 View Progress
-                            </button>
-                        </>
-                    ) : (
-                        <>
-                            <button className="btn btn-primary btn-lg" onClick={() => navigate('/mission/hello-soroban')}>
-                                🚀 Begin Your Journey
-                            </button>
-                            <button className="btn btn-secondary btn-lg" onClick={() => navigate('/missions')}>
-                                🗺️ View Mission Map
-                            </button>
-                        </>
-                    )}
-                </div>
-
-                <div className="hero-stats">
-                    <div className="hero-stat">
-                        <div className="hero-stat-value">{missions.length}</div>
-                        <div className="hero-stat-label">Missions</div>
-                    </div>
-                    <div className="hero-stat">
-                        <div className="hero-stat-value">{missions.reduce((s, m) => s + m.xpReward, 0)}</div>
-                        <div className="hero-stat-label">Total XP</div>
-                    </div>
-                    <div className="hero-stat">
-                        <div className="hero-stat-value">0</div>
-                        <div className="hero-stat-label">Backend Needed</div>
-                    </div>
-                </div>
-            </section>
-
-            <section className="features-section">
-                <h2 className="section-title">How It Works</h2>
-                <p className="section-subtitle">
-                    Your path from zero to Soroban mastery, entirely in the browser.
-                </p>
-
-                <div className="features-grid">
-                    <div className="feature-card">
-                        <div className="feature-icon cyan">📖</div>
-                        <h3>Read the Quest</h3>
-                        <p>
-                            Each mission unfolds a story while teaching core Soroban concepts.
-                            Learn about contracts, storage, tokens, and more through narrative-driven challenges.
-                        </p>
-                    </div>
-
-                    <div className="feature-card">
-                        <div className="feature-icon purple">⌨️</div>
-                        <h3>Write the Code</h3>
-                        <p>
-                            Use the built-in Monaco editor with Rust syntax highlighting and
-                            Soroban autocomplete. Templates get you started — you fill in the logic.
-                        </p>
-                    </div>
-
-                    <div className="feature-card">
-                        <div className="feature-icon gold">🧪</div>
-                        <h3>Run the Tests</h3>
-                        <p>
-                            Validate your code with instant feedback. Each mission has hidden checks
-                            that verify your contract structure, functions, and patterns.
-                        </p>
-                    </div>
-
-                    <div className="feature-card">
-                        <div className="feature-icon cyan">🏆</div>
-                        <h3>Earn XP & Level Up</h3>
-                        <p>
-                            Gain experience points for each completed mission. Unlock badges,
-                            climb ranks, and track your journey from Initiate to Stellar Sovereign.
-                        </p>
-                    </div>
-
-                    <div className="feature-card">
-                        <div className="feature-icon purple">🔒</div>
-                        <h3>Zero Backend</h3>
-                        <p>
-                            Everything runs in your browser. No servers, no databases, no accounts.
-                            Your progress is saved locally — export it anytime as a JSON file.
-                        </p>
-                    </div>
-
-                    <div className="feature-card">
-                        <div className="feature-icon gold">🗺️</div>
-                        <h3>Progressive Path</h3>
-                        <p>
-                            From "Hello World" to multi-signature contracts. Each mission builds
-                            on the last, creating a structured path to Soroban mastery.
-                        </p>
-                    </div>
-                </div>
-            </section>
+        <div className="hero-badge">
+          ✨ Zero setup • No wallet needed • Open source
         </div>
-    );
+
+        <h1 className="hero-title">
+          Master <span className="hero-title-gradient">Soroban</span>
+          <br />
+          Smart Contracts
+        </h1>
+
+        <p className="hero-subtitle">
+          Embark on an epic quest to learn Stellar's smart contract platform.
+          Write real Soroban code in your browser, solve challenges, and level
+          up your blockchain skills — no installation required.
+        </p>
+
+        <div className="hero-actions">
+          {hasMissions ? (
+            <>
+              <button
+                className="btn btn-primary btn-lg"
+                onClick={() => navigate("/missions")}
+              >
+                ⚔️ Continue Quest
+              </button>
+              <button
+                className="btn btn-secondary btn-lg"
+                onClick={() => navigate("/profile")}
+              >
+                📊 View Progress
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                className="btn btn-primary btn-lg"
+                onClick={() => navigate("/mission/hello-soroban")}
+              >
+                🚀 Begin Your Journey
+              </button>
+              <button
+                className="btn btn-secondary btn-lg"
+                onClick={() => navigate("/missions")}
+              >
+                🗺️ View Mission Map
+              </button>
+            </>
+          )}
+        </div>
+
+        <div className="hero-stats">
+          <div className="hero-stat">
+            <div className="hero-stat-value">{missions.length}</div>
+            <div className="hero-stat-label">Missions</div>
+          </div>
+          <div className="hero-stat">
+            <div className="hero-stat-value">
+              {missions.reduce((s, m) => s + m.xpReward, 0)}
+            </div>
+            <div className="hero-stat-label">Total XP</div>
+          </div>
+          <div className="hero-stat">
+            <div className="hero-stat-value">0</div>
+            <div className="hero-stat-label">Backend Needed</div>
+          </div>
+        </div>
+      </section>
+
+      <section className="features-section">
+        <h2 className="section-title">How It Works</h2>
+        <p className="section-subtitle">
+          Your path from zero to Soroban mastery, entirely in the browser.
+        </p>
+
+        <div className="features-grid">
+          <div className="feature-card">
+            <div className="feature-icon cyan">📖</div>
+            <h3>Read the Quest</h3>
+            <p>
+              Each mission unfolds a story while teaching core Soroban concepts.
+              Learn about contracts, storage, tokens, and more through
+              narrative-driven challenges.
+            </p>
+          </div>
+
+          <div className="feature-card">
+            <div className="feature-icon purple">⌨️</div>
+            <h3>Write the Code</h3>
+            <p>
+              Use the built-in Monaco editor with Rust syntax highlighting and
+              Soroban autocomplete. Templates get you started — you fill in the
+              logic.
+            </p>
+          </div>
+
+          <div className="feature-card">
+            <div className="feature-icon gold">🧪</div>
+            <h3>Run the Tests</h3>
+            <p>
+              Validate your code with instant feedback. Each mission has hidden
+              checks that verify your contract structure, functions, and
+              patterns.
+            </p>
+          </div>
+
+          <div className="feature-card">
+            <div className="feature-icon cyan">🏆</div>
+            <h3>Earn XP & Level Up</h3>
+            <p>
+              Gain experience points for each completed mission. Unlock badges,
+              climb ranks, and track your journey from Initiate to Stellar
+              Sovereign.
+            </p>
+          </div>
+
+          <div className="feature-card">
+            <div className="feature-icon purple">🔒</div>
+            <h3>Zero Backend</h3>
+            <p>
+              Everything runs in your browser. No servers, no databases, no
+              accounts. Your progress is saved locally — export it anytime as a
+              JSON file.
+            </p>
+          </div>
+
+          <div className="feature-card">
+            <div className="feature-icon gold">🗺️</div>
+            <h3>Progressive Path</h3>
+            <p>
+              From "Hello World" to multi-signature contracts. Each mission
+              builds on the last, creating a structured path to Soroban mastery.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
 }

--- a/src/pages/Journal.jsx
+++ b/src/pages/Journal.jsx
@@ -1,11 +1,24 @@
 import React, { useState, useMemo } from "react";
-import { getActivityLog, ACTIVITY_TYPES, clearLog } from "../systems/activityLogger";
+import {
+  getActivityLog,
+  ACTIVITY_TYPES,
+  clearLog,
+} from "../systems/activityLogger";
 import { loadProgress } from "../systems/storage";
+import { useDocumentTitle } from "../systems/useDocumentTitle";
 import "./Journal.css";
 
 const EVENT_CONFIG = {
-  [ACTIVITY_TYPES.MISSION_STARTED]: { icon: "⚔️", class: "mission", label: "Mission" },
-  [ACTIVITY_TYPES.MISSION_COMPLETED]: { icon: "🗡️", class: "mission", label: "Mission" },
+  [ACTIVITY_TYPES.MISSION_STARTED]: {
+    icon: "⚔️",
+    class: "mission",
+    label: "Mission",
+  },
+  [ACTIVITY_TYPES.MISSION_COMPLETED]: {
+    icon: "🗡️",
+    class: "mission",
+    label: "Mission",
+  },
   [ACTIVITY_TYPES.BADGE_EARNED]: { icon: "🏅", class: "badge", label: "Badge" },
   [ACTIVITY_TYPES.LEVEL_UP]: { icon: "⬆️", class: "level", label: "Level Up" },
   [ACTIVITY_TYPES.HINT_USED]: { icon: "💡", class: "hint", label: "Hint" },
@@ -19,9 +32,11 @@ export default function Journal() {
   const [filter, setFilter] = useState("ALL");
   const progress = loadProgress();
 
+  useDocumentTitle("Journal");
+
   const filteredLog = useMemo(() => {
     if (filter === "ALL") return log;
-    return log.filter(entry => {
+    return log.filter((entry) => {
       const config = EVENT_CONFIG[entry.type];
       return config && config.label.toUpperCase() === filter;
     });
@@ -30,7 +45,7 @@ export default function Journal() {
   // Group by date
   const groupedLog = useMemo(() => {
     const groups = {};
-    filteredLog.forEach(entry => {
+    filteredLog.forEach((entry) => {
       const date = new Date(entry.timestamp);
       const dateStr = formatDateHeader(date);
       if (!groups[dateStr]) groups[dateStr] = [];
@@ -51,9 +66,15 @@ export default function Journal() {
       <div className="journal-header flex justify-between items-end">
         <div>
           <h1 className="journal-title">Adventure Journal</h1>
-          <p className="text-secondary">Your journey through the Soroban realm, recorded for eternity.</p>
+          <p className="text-secondary">
+            Your journey through the Soroban realm, recorded for eternity.
+          </p>
         </div>
-        <button className="btn btn-ghost btn-sm" style={{ color: "var(--red)" }} onClick={handleClear}>
+        <button
+          className="btn btn-ghost btn-sm"
+          style={{ color: "var(--red)" }}
+          onClick={handleClear}
+        >
           🗑️ Clear Log
         </button>
       </div>
@@ -61,7 +82,9 @@ export default function Journal() {
       {/* Summary Stats */}
       <div className="adventure-summary">
         <div className="summary-stat">
-          <span className="summary-stat-value">{progress.completedMissions.length}</span>
+          <span className="summary-stat-value">
+            {progress.completedMissions.length}
+          </span>
           <span className="summary-stat-label">Missions</span>
         </div>
         <div className="summary-stat">
@@ -84,9 +107,9 @@ export default function Journal() {
 
       {/* Filters */}
       <div className="journal-filters">
-        {["ALL", "MISSION", "BADGE", "LEVEL UP", "HINT", "SYSTEM"].map(f => (
-          <button 
-            key={f} 
+        {["ALL", "MISSION", "BADGE", "LEVEL UP", "HINT", "SYSTEM"].map((f) => (
+          <button
+            key={f}
             className={`filter-chip ${filter === f ? "active" : ""}`}
             onClick={() => setFilter(f)}
           >
@@ -98,18 +121,28 @@ export default function Journal() {
       {/* Timeline */}
       {Object.keys(groupedLog).length === 0 ? (
         <div className="card text-center p-12">
-          <div style={{ fontSize: "3rem", marginBottom: "1rem", opacity: 0.3 }}>📖</div>
-          <p className="text-secondary">No activities recorded yet. Start your first mission!</p>
+          <div style={{ fontSize: "3rem", marginBottom: "1rem", opacity: 0.3 }}>
+            📖
+          </div>
+          <p className="text-secondary">
+            No activities recorded yet. Start your first mission!
+          </p>
         </div>
       ) : (
         <div className="timeline">
           {Object.entries(groupedLog).map(([date, entries]) => (
             <div key={date} className="date-group">
               <div className="date-header">{date}</div>
-              {entries.map(entry => {
-                const config = EVENT_CONFIG[entry.type] || { icon: "❓", class: "system" };
-                const time = new Date(entry.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-                
+              {entries.map((entry) => {
+                const config = EVENT_CONFIG[entry.type] || {
+                  icon: "❓",
+                  class: "system",
+                };
+                const time = new Date(entry.timestamp).toLocaleTimeString([], {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                });
+
                 return (
                   <div key={entry.id} className="timeline-event">
                     <div className={`event-dot ${config.class}`}>
@@ -120,8 +153,10 @@ export default function Journal() {
                       <div className="event-message">{entry.message}</div>
                       {entry.data && Object.keys(entry.data).length > 0 && (
                         <div className="event-details">
-                          {entry.type === ACTIVITY_TYPES.LEVEL_UP && `Target XP reached: ${progress.xp}`}
-                          {entry.type === ACTIVITY_TYPES.MISSION_COMPLETED && `Earned ${entry.data.xp || ""} XP`}
+                          {entry.type === ACTIVITY_TYPES.LEVEL_UP &&
+                            `Target XP reached: ${progress.xp}`}
+                          {entry.type === ACTIVITY_TYPES.MISSION_COMPLETED &&
+                            `Earned ${entry.data.xp || ""} XP`}
                         </div>
                       )}
                     </div>
@@ -144,15 +179,17 @@ function formatDateHeader(date) {
   if (isSameDay(date, today)) return "Today";
   if (isSameDay(date, yesterday)) return "Yesterday";
 
-  return date.toLocaleDateString("en-US", { 
-    month: "long", 
-    day: "numeric", 
-    year: date.getFullYear() !== today.getFullYear() ? "numeric" : undefined 
+  return date.toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: date.getFullYear() !== today.getFullYear() ? "numeric" : undefined,
   });
 }
 
 function isSameDay(d1, d2) {
-  return d1.getFullYear() === d2.getFullYear() &&
-         d1.getMonth() === d2.getMonth() &&
-         d1.getDate() === d2.getDate();
+  return (
+    d1.getFullYear() === d2.getFullYear() &&
+    d1.getMonth() === d2.getMonth() &&
+    d1.getDate() === d2.getDate()
+  );
 }

--- a/src/pages/MissionDetail.jsx
+++ b/src/pages/MissionDetail.jsx
@@ -5,7 +5,11 @@ import ReactMarkdown from "react-markdown";
 import { getMissionById, getNextMission } from "../systems/missionLoader";
 import { runTests } from "../systems/testRunner";
 import { loadProgress, saveProgress } from "../systems/storage";
-import { completeMission, recordAttempt, getRankTitle } from "../systems/gameEngine";
+import {
+  completeMission,
+  recordAttempt,
+  getRankTitle,
+} from "../systems/gameEngine";
 import { logActivity, ACTIVITY_TYPES } from "../systems/activityLogger";
 import MissionDetailSkeleton from "../components/MissionDetailSkeleton";
 import { useokashi, TOAST_STATES } from "../systems/useokashi";
@@ -14,6 +18,7 @@ import { useToast } from "../systems/ToastContext";
 import { MissionErrorBoundary } from "../components/ErrorBoundary";
 import CodeReplayPlayer from "../components/CodeReplayPlayer";
 import CodeRecorder from "../systems/codeRecorder";
+import { useDocumentTitle } from "../systems/useDocumentTitle";
 
 // ─── Monaco marker model name (must be consistent across calls) ──────────────
 const LIVE_MARKER_OWNER = "soroban-quest-live";
@@ -26,6 +31,8 @@ export default function MissionDetail() {
   // Safe fallback in case ToastContext is not provided
   const toastContext = useToast();
   const showToast = toastContext?.showToast;
+
+  useDocumentTitle(mission ? `Mission: ${mission.title}` : "Mission");
 
   // --------------------------- States ---------------------------
   const [loading, setLoading] = useState(true);
@@ -43,9 +50,9 @@ export default function MissionDetail() {
   const [liveTotalCount, setLiveTotalCount] = useState(0);
 
   const terminalBodyRef = useRef(null);
-  const editorRef = useRef(null);       // Monaco editor instance
-  const monacoRef = useRef(null);       // Monaco global (for setModelMarkers)
-  const validatorRef = useRef(null);    // Debounced validator handle
+  const editorRef = useRef(null); // Monaco editor instance
+  const monacoRef = useRef(null); // Monaco global (for setModelMarkers)
+  const validatorRef = useRef(null); // Debounced validator handle
 
   const { openInOkashi, toast } = useokashi();
 
@@ -66,7 +73,11 @@ export default function MissionDetail() {
         setLivePassCount(0);
         setLiveTotalCount(0);
         setLoading(false);
-        logActivity(ACTIVITY_TYPES.MISSION_STARTED, { missionId, title: mission.title }, `Started mission: ${mission.title}`);
+        logActivity(
+          ACTIVITY_TYPES.MISSION_STARTED,
+          { missionId, title: mission.title },
+          `Started mission: ${mission.title}`,
+        );
       }, 1500);
     } else {
       setLoading(false);
@@ -222,7 +233,11 @@ export default function MissionDetail() {
       const nextIndex = hintIndex + 1;
       setHintIndex(nextIndex);
       if (showToast) showToast(`Hint ${nextIndex + 1} unlocked`, "info");
-      logActivity(ACTIVITY_TYPES.HINT_USED, { missionId, hintIndex: nextIndex }, `Used hint ${nextIndex + 1} for ${mission.title}`);
+      logActivity(
+        ACTIVITY_TYPES.HINT_USED,
+        { missionId, hintIndex: nextIndex },
+        `Used hint ${nextIndex + 1} for ${mission.title}`,
+      );
     }
   };
 
@@ -292,7 +307,9 @@ export default function MissionDetail() {
   // --------------------------- Render Mission Detail ---------------------------
   if (showReplay) {
     return (
-      <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <div
+        style={{ height: "100vh", display: "flex", flexDirection: "column" }}
+      >
         <CodeReplayPlayer
           missionId={missionId}
           recording={replayData}
@@ -486,10 +503,14 @@ export default function MissionDetail() {
               <span style={{ color: sbState.color, transition: "color 0.3s" }}>
                 {sbState.label}
               </span>
-              <span style={{ color: "rgba(255,255,255,0.15)", fontSize: "10px" }}>
+              <span
+                style={{ color: "rgba(255,255,255,0.15)", fontSize: "10px" }}
+              >
                 |
               </span>
-              <span style={{ color: "rgba(255,255,255,0.3)", fontSize: "10.5px" }}>
+              <span
+                style={{ color: "rgba(255,255,255,0.3)", fontSize: "10.5px" }}
+              >
                 live checks · full suite on Run Tests
               </span>
             </div>
@@ -531,8 +552,8 @@ export default function MissionDetail() {
                         r.passed === true
                           ? "pass"
                           : r.passed === false
-                          ? "fail"
-                          : "info"
+                            ? "fail"
+                            : "info"
                       }`}
                     >
                       {r.message}
@@ -546,23 +567,28 @@ export default function MissionDetail() {
 
         {/* ---------------- Replay Panel ---------------- */}
         {isCompleted && hasReplay && (
-          <div className="mission-replay-panel" style={{
-            display: 'none',
-            padding: '2rem',
-            textAlign: 'center',
-            background: 'var(--bg-secondary)',
-            borderTop: '1px solid var(--border-subtle)'
-          }}>
-            <h3 style={{ marginBottom: '1rem', color: 'var(--text-primary)' }}>
+          <div
+            className="mission-replay-panel"
+            style={{
+              display: "none",
+              padding: "2rem",
+              textAlign: "center",
+              background: "var(--bg-secondary)",
+              borderTop: "1px solid var(--border-subtle)",
+            }}
+          >
+            <h3 style={{ marginBottom: "1rem", color: "var(--text-primary)" }}>
               📹 Watch Your Solution
             </h3>
-            <p style={{ color: 'var(--text-secondary)', marginBottom: '1.5rem' }}>
+            <p
+              style={{ color: "var(--text-secondary)", marginBottom: "1.5rem" }}
+            >
               Review your problem-solving process step by step.
             </p>
             <button
               className="btn btn-primary"
               onClick={handleWatchReplay}
-              style={{ fontSize: '1rem', padding: '0.75rem 2rem' }}
+              style={{ fontSize: "1rem", padding: "0.75rem 2rem" }}
             >
               ▶️ Start Replay
             </button>
@@ -596,7 +622,8 @@ export default function MissionDetail() {
 
             {victoryData.newBadges?.length > 0 && (
               <p style={{ color: "var(--gold)", marginBottom: "1rem" }}>
-                🏅 New badge{victoryData.newBadges.length > 1 ? "s" : ""} earned!
+                🏅 New badge{victoryData.newBadges.length > 1 ? "s" : ""}{" "}
+                earned!
               </p>
             )}
 
@@ -657,9 +684,13 @@ export default function MissionDetail() {
                     fontSize: "13px",
                     fontWeight: "500",
                     background:
-                      toast.state === TOAST_STATES.SUCCESS ? "#064e3b" : "#4c0519",
+                      toast.state === TOAST_STATES.SUCCESS
+                        ? "#064e3b"
+                        : "#4c0519",
                     color:
-                      toast.state === TOAST_STATES.SUCCESS ? "#6ee7b7" : "#fda4af",
+                      toast.state === TOAST_STATES.SUCCESS
+                        ? "#6ee7b7"
+                        : "#fda4af",
                     border:
                       toast.state === TOAST_STATES.SUCCESS
                         ? "1px solid #065f46"

--- a/src/pages/MissionMap.jsx
+++ b/src/pages/MissionMap.jsx
@@ -1,352 +1,435 @@
-import React, { useState, useMemo, useRef, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { loadProgress } from '../systems/storage';
-import { getAllMissions, isMissionUnlocked } from '../systems/missionLoader';
+import React, { useState, useMemo, useRef, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { loadProgress } from "../systems/storage";
+import { getAllMissions, isMissionUnlocked } from "../systems/missionLoader";
+import { useDocumentTitle } from "../systems/useDocumentTitle";
 
 export default function MissionMap() {
-    const navigate = useNavigate();
-    const state = loadProgress();
-    const missions = getAllMissions();
-    const learningPathRef = useRef(null);
-    const [learningPathWidth, setLearningPathWidth] = useState(800);
-    const [searchTerm, setSearchTerm] = useState('');
-    const [selectedDifficulty, setSelectedDifficulty] = useState('all');
-    const [selectedChapter, setSelectedChapter] = useState('all');
+  const navigate = useNavigate();
+  const state = loadProgress();
+  const missions = getAllMissions();
+  const learningPathRef = useRef(null);
+  const [learningPathWidth, setLearningPathWidth] = useState(800);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedDifficulty, setSelectedDifficulty] = useState("all");
+  const [selectedChapter, setSelectedChapter] = useState("all");
 
-    const missionStates = useMemo(() => {
-        return missions.map((m) => ({
-            ...m,
-            completed: state.completedMissions.includes(m.id),
-            unlocked: isMissionUnlocked(m.id, state.completedMissions),
-        }));
-    }, [state.completedMissions]);
+  useDocumentTitle("Mission Map");
 
-    const filteredMissions = useMemo(() => {
-        return missionStates.filter((mission) => {
-            const matchesSearch = searchTerm === '' ||
-                mission.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                mission.learningGoal.toLowerCase().includes(searchTerm.toLowerCase());
-            const matchesDifficulty = selectedDifficulty === 'all' || mission.difficulty === selectedDifficulty;
-            const matchesChapter = selectedChapter === 'all' || mission.chapter === selectedChapter;
-            return matchesSearch && matchesDifficulty && matchesChapter;
-        });
-    }, [missionStates, searchTerm, selectedDifficulty, selectedChapter]);
+  const missionStates = useMemo(() => {
+    return missions.map((m) => ({
+      ...m,
+      completed: state.completedMissions.includes(m.id),
+      unlocked: isMissionUnlocked(m.id, state.completedMissions),
+    }));
+  }, [state.completedMissions]);
 
-    const handleMissionClick = (mission) => {
-        if (mission.unlocked) {
-            navigate(`/mission/${mission.id}`);
-        }
+  const filteredMissions = useMemo(() => {
+    return missionStates.filter((mission) => {
+      const matchesSearch =
+        searchTerm === "" ||
+        mission.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        mission.learningGoal.toLowerCase().includes(searchTerm.toLowerCase());
+      const matchesDifficulty =
+        selectedDifficulty === "all" ||
+        mission.difficulty === selectedDifficulty;
+      const matchesChapter =
+        selectedChapter === "all" || mission.chapter === selectedChapter;
+      return matchesSearch && matchesDifficulty && matchesChapter;
+    });
+  }, [missionStates, searchTerm, selectedDifficulty, selectedChapter]);
+
+  const handleMissionClick = (mission) => {
+    if (mission.unlocked) {
+      navigate(`/mission/${mission.id}`);
+    }
+  };
+
+  useEffect(() => {
+    if (!learningPathRef.current || typeof ResizeObserver === "undefined") {
+      return undefined;
+    }
+
+    const node = learningPathRef.current;
+    const updateWidth = (width) => {
+      setLearningPathWidth(Math.max(320, Math.floor(width)));
     };
 
-    useEffect(() => {
-        if (!learningPathRef.current || typeof ResizeObserver === 'undefined') {
-            return undefined;
-        }
+    updateWidth(node.getBoundingClientRect().width);
 
-        const node = learningPathRef.current;
-        const updateWidth = (width) => {
-            setLearningPathWidth(Math.max(320, Math.floor(width)));
-        };
+    const observer = new ResizeObserver((entries) => {
+      if (entries[0]) {
+        updateWidth(entries[0].contentRect.width);
+      }
+    });
 
-        updateWidth(node.getBoundingClientRect().width);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
 
-        const observer = new ResizeObserver((entries) => {
-            if (entries[0]) {
-                updateWidth(entries[0].contentRect.width);
-            }
-        });
+  const desktopPathLayout = useMemo(() => {
+    const width = Math.max(learningPathWidth, 320);
+    const cols = width >= 1024 ? 4 : width >= 860 ? 3 : 2;
+    const rows = Math.ceil(filteredMissions.length / cols);
+    const topPadding = 70;
+    const horizontalPadding = cols === 2 ? 72 : 80;
+    const rowSpacing = 140;
+    const bottomPadding = 110;
+    const usableWidth = Math.max(width - horizontalPadding * 2, 1);
+    const colSpacing = cols > 1 ? usableWidth / (cols - 1) : 0;
 
-        observer.observe(node);
-        return () => observer.disconnect();
-    }, []);
+    const points = filteredMissions.map((m, i) => {
+      const row = Math.floor(i / cols);
+      const colInRow = i % cols;
+      const isReverse = row % 2 === 1;
+      const col = isReverse ? cols - 1 - colInRow : colInRow;
 
-    const desktopPathLayout = useMemo(() => {
-        const width = Math.max(learningPathWidth, 320);
-        const cols = width >= 1024 ? 4 : width >= 860 ? 3 : 2;
-        const rows = Math.ceil(filteredMissions.length / cols);
-        const topPadding = 70;
-        const horizontalPadding = cols === 2 ? 72 : 80;
-        const rowSpacing = 140;
-        const bottomPadding = 110;
-        const usableWidth = Math.max(width - horizontalPadding * 2, 1);
-        const colSpacing = cols > 1 ? usableWidth / (cols - 1) : 0;
+      return {
+        mission: m,
+        cx: horizontalPadding + col * colSpacing,
+        cy: topPadding + row * rowSpacing,
+        index: i,
+      };
+    });
 
-        const points = filteredMissions.map((m, i) => {
-            const row = Math.floor(i / cols);
-            const colInRow = i % cols;
-            const isReverse = row % 2 === 1;
-            const col = isReverse ? cols - 1 - colInRow : colInRow;
+    const height =
+      topPadding + Math.max(0, rows - 1) * rowSpacing + bottomPadding;
 
-            return {
-                mission: m,
-                cx: horizontalPadding + col * colSpacing,
-                cy: topPadding + row * rowSpacing,
-                index: i,
-            };
-        });
+    return {
+      width: Math.round(width),
+      height: Math.round(Math.max(height, 280)),
+      points,
+    };
+  }, [learningPathWidth, filteredMissions]);
 
-        const height = topPadding + Math.max(0, rows - 1) * rowSpacing + bottomPadding;
+  return (
+    <div className="mission-map-page">
+      <div className="mission-map-header">
+        <h1 className="section-title">Mission Map</h1>
+        <p className="section-subtitle">
+          {state.completedMissions.length} of {missions.length} missions
+          completed
+        </p>
+      </div>
 
-        return {
-            width: Math.round(width),
-            height: Math.round(Math.max(height, 280)),
-            points,
-        };
-    }, [learningPathWidth, filteredMissions]);
+      {/* SVG Learning Path */}
+      <div
+        className="learning-path learning-path-desktop"
+        ref={learningPathRef}
+      >
+        <svg
+          viewBox={`0 0 ${desktopPathLayout.width} ${desktopPathLayout.height}`}
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          role="img"
+          aria-label="Mission path graph"
+        >
+          {desktopPathLayout.points.map(({ mission, cx, cy, index }) => {
+            const next = desktopPathLayout.points[index + 1];
+            const nodeColor = mission.completed
+              ? "#22c55e"
+              : mission.unlocked
+                ? "#06d6a0"
+                : "#374151";
+            const textColor = mission.completed
+              ? "#22c55e"
+              : mission.unlocked
+                ? "#f1f5f9"
+                : "#4b5563";
+            const glowFilter = mission.completed
+              ? "url(#glowGreen)"
+              : mission.unlocked
+                ? "url(#glowCyan)"
+                : "";
+            const shortTitle =
+              mission.title.length > 20
+                ? `${mission.title.slice(0, 19)}…`
+                : mission.title;
 
-    return (
-        <div className="mission-map-page">
-            <div className="mission-map-header">
-                <h1 className="section-title">Mission Map</h1>
-                <p className="section-subtitle">
-                    {state.completedMissions.length} of {missions.length} missions completed
-                </p>
-            </div>
-
-            {/* SVG Learning Path */}
-            <div className="learning-path learning-path-desktop" ref={learningPathRef}>
-                <svg
-                    viewBox={`0 0 ${desktopPathLayout.width} ${desktopPathLayout.height}`}
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                    role="img"
-                    aria-label="Mission path graph"
-                >
-                    {desktopPathLayout.points.map(({ mission, cx, cy, index }) => {
-                        const next = desktopPathLayout.points[index + 1];
-                        const nodeColor = mission.completed ? '#22c55e' : mission.unlocked ? '#06d6a0' : '#374151';
-                        const textColor = mission.completed ? '#22c55e' : mission.unlocked ? '#f1f5f9' : '#4b5563';
-                        const glowFilter = mission.completed ? 'url(#glowGreen)' : mission.unlocked ? 'url(#glowCyan)' : '';
-                        const shortTitle = mission.title.length > 20 ? `${mission.title.slice(0, 19)}…` : mission.title;
-
-                        return (
-                            <g key={mission.id}>
-                                {next && (
-                                    <line
-                                        x1={cx}
-                                        y1={cy}
-                                        x2={next.cx}
-                                        y2={next.cy}
-                                        stroke={mission.completed ? '#22c55e' : '#1f2937'}
-                                        strokeWidth="2"
-                                        strokeDasharray={mission.completed ? '' : '6 4'}
-                                        className={mission.completed ? 'path-line completed' : 'path-line'}
-                                    />
-                                )}
-                                <g
-                                    className="path-node"
-                                    onClick={() => handleMissionClick(mission)}
-                                    onKeyDown={(event) => {
-                                        if (mission.unlocked && (event.key === 'Enter' || event.key === ' ')) {
-                                            event.preventDefault();
-                                            handleMissionClick(mission);
-                                        }
-                                    }}
-                                    role={mission.unlocked ? 'button' : undefined}
-                                    tabIndex={mission.unlocked ? 0 : -1}
-                                    aria-label={`Mission ${mission.order}: ${mission.title}`}
-                                    style={{ cursor: mission.unlocked ? 'pointer' : 'not-allowed' }}
-                                >
-                                    <circle className="path-node-hit-area" cx={cx} cy={cy} r="28" fill="transparent" />
-                                    <circle
-                                        className="path-node-circle"
-                                        cx={cx}
-                                        cy={cy}
-                                        r="24"
-                                        fill={mission.completed ? 'rgba(34,197,94,0.15)' : mission.unlocked ? 'rgba(6,214,160,0.1)' : 'rgba(31,41,55,0.5)'}
-                                        stroke={nodeColor}
-                                        strokeWidth="2"
-                                        filter={glowFilter}
-                                    />
-                                    <text
-                                        x={cx}
-                                        y={cy + 1}
-                                        textAnchor="middle"
-                                        dominantBaseline="middle"
-                                        fill={mission.completed ? '#22c55e' : mission.unlocked ? '#06d6a0' : '#6b7280'}
-                                        fontSize="14"
-                                        fontWeight="bold"
-                                    >
-                                        {mission.completed ? '✓' : mission.unlocked ? mission.order : '🔒'}
-                                    </text>
-                                    <text
-                                        x={cx}
-                                        y={cy + 42}
-                                        textAnchor="middle"
-                                        fill={textColor}
-                                        fontSize="11"
-                                        fontWeight="500"
-                                        fontFamily="Inter, sans-serif"
-                                    >
-                                        {shortTitle}
-                                    </text>
-                                    <text
-                                        x={cx}
-                                        y={cy + 56}
-                                        textAnchor="middle"
-                                        fill={mission.completed ? '#22c55e' : '#f59e0b'}
-                                        fontSize="9"
-                                        fontWeight="600"
-                                        fontFamily="Orbitron, sans-serif"
-                                    >
-                                        {mission.completed ? 'COMPLETED' : `${mission.xpReward} XP`}
-                                    </text>
-                                </g>
-                            </g>
-                        );
-                    })}
-                    <defs>
-                        <filter id="glowCyan" x="-50%" y="-50%" width="200%" height="200%">
-                            <feGaussianBlur in="SourceGraphic" stdDeviation="4" result="blur" />
-                            <feFlood floodColor="var(--cyan)" floodOpacity="0.4" />
-                            <feComposite in2="blur" operator="in" />
-                            <feMerge><feMergeNode /><feMergeNode in="SourceGraphic" /></feMerge>
-                        </filter>
-                        <filter id="glowGreen" x="-50%" y="-50%" width="200%" height="200%">
-                            <feGaussianBlur in="SourceGraphic" stdDeviation="4" result="blur" />
-                            <feFlood floodColor="var(--green)" floodOpacity="0.4" />
-                            <feComposite in2="blur" operator="in" />
-                            <feMerge><feMergeNode /><feMergeNode in="SourceGraphic" /></feMerge>
-                        </filter>
-                    </defs>
-                </svg>
-            </div>
-            <div className="learning-path-mobile" aria-label="Mission timeline">
-                {filteredMissions.map((m, i) => (
-                    <button
-                        type="button"
-                        key={m.id}
-                        className={`timeline-item ${m.completed ? 'completed' : ''} ${!m.unlocked ? 'locked' : ''}`}
-                        onClick={() => handleMissionClick(m)}
-                        disabled={!m.unlocked}
-                        aria-label={`Mission ${m.order}: ${m.title}${m.completed ? ', completed' : m.unlocked ? ', unlocked' : ', locked'}`}
-                    >
-                        <span className="timeline-track" aria-hidden="true">
-                            <span className="timeline-node">
-                                {m.completed ? '✓' : m.unlocked ? m.order : '🔒'}
-                            </span>
-                            {i < filteredMissions.length - 1 && (
-                                <span className={`timeline-line ${m.completed ? 'completed' : ''}`} />
-                            )}
-                        </span>
-                        <span className="timeline-body">
-                            <span className="timeline-meta">
-                                Chapter {m.chapter} • Mission {m.order}
-                            </span>
-                            <span className="timeline-title">{m.title}</span>
-                            <span className="timeline-foot">
-                                <span className="timeline-xp">⚡ {m.xpReward} XP</span>
-                                <span className={`badge badge-${m.difficulty}`}>{m.difficulty}</span>
-                            </span>
-                        </span>
-                    </button>
-                ))}
-            </div>
-
-            {/* Mission Cards Grid */}
-            <div className="mission-map-filters">
-                <div className="search-bar">
-                    <input
-                        type="text"
-                        placeholder="Search missions..."
-                        value={searchTerm}
-                        onChange={(e) => setSearchTerm(e.target.value)}
-                        className="search-input"
-                    />
-                </div>
-                <div className="filter-chips">
-                    <div className="difficulty-filters">
-                        <button
-                            className={`filter-chip ${selectedDifficulty === 'all' ? 'active' : ''}`}
-                            onClick={() => setSelectedDifficulty('all')}
-                        >
-                            All
-                        </button>
-                        <button
-                            className={`filter-chip ${selectedDifficulty === 'beginner' ? 'active' : ''}`}
-                            onClick={() => setSelectedDifficulty('beginner')}
-                        >
-                            Beginner
-                        </button>
-                        <button
-                            className={`filter-chip ${selectedDifficulty === 'intermediate' ? 'active' : ''}`}
-                            onClick={() => setSelectedDifficulty('intermediate')}
-                        >
-                            Intermediate
-                        </button>
-                        <button
-                            className={`filter-chip ${selectedDifficulty === 'advanced' ? 'active' : ''}`}
-                            onClick={() => setSelectedDifficulty('advanced')}
-                        >
-                            Advanced
-                        </button>
-                    </div>
-                    <div className="chapter-filters">
-                        <button
-                            className={`filter-chip ${selectedChapter === 'all' ? 'active' : ''}`}
-                            onClick={() => setSelectedChapter('all')}
-                        >
-                            All Chapters
-                        </button>
-                        <button
-                            className={`filter-chip ${selectedChapter === 1 ? 'active' : ''}`}
-                            onClick={() => setSelectedChapter(1)}
-                        >
-                            Chapter 1
-                        </button>
-                        <button
-                            className={`filter-chip ${selectedChapter === 2 ? 'active' : ''}`}
-                            onClick={() => setSelectedChapter(2)}
-                        >
-                            Chapter 2
-                        </button>
-                        <button
-                            className={`filter-chip ${selectedChapter === 3 ? 'active' : ''}`}
-                            onClick={() => setSelectedChapter(3)}
-                        >
-                            Chapter 3
-                        </button>
-                    </div>
-                </div>
-            </div>
-            <div className="mission-map-grid">
-                {filteredMissions.length === 0 ? (
-                    <div className="no-missions-found">
-                        <p>No missions found matching your filters.</p>
-                    </div>
-                ) : (
-                    filteredMissions.map((m) => (
-                        <div
-                            key={m.id}
-                            className={`mission-card ${m.completed ? 'completed' : ''} ${!m.unlocked ? 'locked' : ''}`}
-                            onClick={() => handleMissionClick(m)}
-                        >
-                            <div className="mission-card-header">
-                                <span className="mission-card-chapter">Chapter {m.chapter} • Mission {m.order}</span>
-                                <span className="mission-card-xp">⚡ {m.xpReward} XP</span>
-                            </div>
-                            <h3 className="mission-card-title">{m.title}</h3>
-                            <p className="mission-card-desc">{m.learningGoal}</p>
-                            <div className="mission-card-footer">
-                                <div className="mission-card-concepts">
-                                    {m.conceptsIntroduced.slice(0, 3).map(c => (
-                                        <span key={c} className="concept-tag">{c}</span>
-                                    ))}
-                                </div>
-                                <span className={`badge badge-${m.difficulty}`}>
-                                    {m.difficulty}
-                                </span>
-                            </div>
-                            {m.completed && (
-                                <div className="mission-card-status completed">✓ Completed</div>
-                            )}
-                            {!m.unlocked && (
-                                <div className="mission-card-status" style={{ color: 'var(--text-muted)' }}>🔒 Locked</div>
-                            )}
-                        </div>
-                    ))
+            return (
+              <g key={mission.id}>
+                {next && (
+                  <line
+                    x1={cx}
+                    y1={cy}
+                    x2={next.cx}
+                    y2={next.cy}
+                    stroke={mission.completed ? "#22c55e" : "#1f2937"}
+                    strokeWidth="2"
+                    strokeDasharray={mission.completed ? "" : "6 4"}
+                    className={
+                      mission.completed ? "path-line completed" : "path-line"
+                    }
+                  />
                 )}
-            </div>
+                <g
+                  className="path-node"
+                  onClick={() => handleMissionClick(mission)}
+                  onKeyDown={(event) => {
+                    if (
+                      mission.unlocked &&
+                      (event.key === "Enter" || event.key === " ")
+                    ) {
+                      event.preventDefault();
+                      handleMissionClick(mission);
+                    }
+                  }}
+                  role={mission.unlocked ? "button" : undefined}
+                  tabIndex={mission.unlocked ? 0 : -1}
+                  aria-label={`Mission ${mission.order}: ${mission.title}`}
+                  style={{
+                    cursor: mission.unlocked ? "pointer" : "not-allowed",
+                  }}
+                >
+                  <circle
+                    className="path-node-hit-area"
+                    cx={cx}
+                    cy={cy}
+                    r="28"
+                    fill="transparent"
+                  />
+                  <circle
+                    className="path-node-circle"
+                    cx={cx}
+                    cy={cy}
+                    r="24"
+                    fill={
+                      mission.completed
+                        ? "rgba(34,197,94,0.15)"
+                        : mission.unlocked
+                          ? "rgba(6,214,160,0.1)"
+                          : "rgba(31,41,55,0.5)"
+                    }
+                    stroke={nodeColor}
+                    strokeWidth="2"
+                    filter={glowFilter}
+                  />
+                  <text
+                    x={cx}
+                    y={cy + 1}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    fill={
+                      mission.completed
+                        ? "#22c55e"
+                        : mission.unlocked
+                          ? "#06d6a0"
+                          : "#6b7280"
+                    }
+                    fontSize="14"
+                    fontWeight="bold"
+                  >
+                    {mission.completed
+                      ? "✓"
+                      : mission.unlocked
+                        ? mission.order
+                        : "🔒"}
+                  </text>
+                  <text
+                    x={cx}
+                    y={cy + 42}
+                    textAnchor="middle"
+                    fill={textColor}
+                    fontSize="11"
+                    fontWeight="500"
+                    fontFamily="Inter, sans-serif"
+                  >
+                    {shortTitle}
+                  </text>
+                  <text
+                    x={cx}
+                    y={cy + 56}
+                    textAnchor="middle"
+                    fill={mission.completed ? "#22c55e" : "#f59e0b"}
+                    fontSize="9"
+                    fontWeight="600"
+                    fontFamily="Orbitron, sans-serif"
+                  >
+                    {mission.completed ? "COMPLETED" : `${mission.xpReward} XP`}
+                  </text>
+                </g>
+              </g>
+            );
+          })}
+          <defs>
+            <filter id="glowCyan" x="-50%" y="-50%" width="200%" height="200%">
+              <feGaussianBlur
+                in="SourceGraphic"
+                stdDeviation="4"
+                result="blur"
+              />
+              <feFlood floodColor="var(--cyan)" floodOpacity="0.4" />
+              <feComposite in2="blur" operator="in" />
+              <feMerge>
+                <feMergeNode />
+                <feMergeNode in="SourceGraphic" />
+              </feMerge>
+            </filter>
+            <filter id="glowGreen" x="-50%" y="-50%" width="200%" height="200%">
+              <feGaussianBlur
+                in="SourceGraphic"
+                stdDeviation="4"
+                result="blur"
+              />
+              <feFlood floodColor="var(--green)" floodOpacity="0.4" />
+              <feComposite in2="blur" operator="in" />
+              <feMerge>
+                <feMergeNode />
+                <feMergeNode in="SourceGraphic" />
+              </feMerge>
+            </filter>
+          </defs>
+        </svg>
+      </div>
+      <div className="learning-path-mobile" aria-label="Mission timeline">
+        {filteredMissions.map((m, i) => (
+          <button
+            type="button"
+            key={m.id}
+            className={`timeline-item ${m.completed ? "completed" : ""} ${!m.unlocked ? "locked" : ""}`}
+            onClick={() => handleMissionClick(m)}
+            disabled={!m.unlocked}
+            aria-label={`Mission ${m.order}: ${m.title}${m.completed ? ", completed" : m.unlocked ? ", unlocked" : ", locked"}`}
+          >
+            <span className="timeline-track" aria-hidden="true">
+              <span className="timeline-node">
+                {m.completed ? "✓" : m.unlocked ? m.order : "🔒"}
+              </span>
+              {i < filteredMissions.length - 1 && (
+                <span
+                  className={`timeline-line ${m.completed ? "completed" : ""}`}
+                />
+              )}
+            </span>
+            <span className="timeline-body">
+              <span className="timeline-meta">
+                Chapter {m.chapter} • Mission {m.order}
+              </span>
+              <span className="timeline-title">{m.title}</span>
+              <span className="timeline-foot">
+                <span className="timeline-xp">⚡ {m.xpReward} XP</span>
+                <span className={`badge badge-${m.difficulty}`}>
+                  {m.difficulty}
+                </span>
+              </span>
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {/* Mission Cards Grid */}
+      <div className="mission-map-filters">
+        <div className="search-bar">
+          <input
+            type="text"
+            placeholder="Search missions..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="search-input"
+          />
         </div>
-    );
+        <div className="filter-chips">
+          <div className="difficulty-filters">
+            <button
+              className={`filter-chip ${selectedDifficulty === "all" ? "active" : ""}`}
+              onClick={() => setSelectedDifficulty("all")}
+            >
+              All
+            </button>
+            <button
+              className={`filter-chip ${selectedDifficulty === "beginner" ? "active" : ""}`}
+              onClick={() => setSelectedDifficulty("beginner")}
+            >
+              Beginner
+            </button>
+            <button
+              className={`filter-chip ${selectedDifficulty === "intermediate" ? "active" : ""}`}
+              onClick={() => setSelectedDifficulty("intermediate")}
+            >
+              Intermediate
+            </button>
+            <button
+              className={`filter-chip ${selectedDifficulty === "advanced" ? "active" : ""}`}
+              onClick={() => setSelectedDifficulty("advanced")}
+            >
+              Advanced
+            </button>
+          </div>
+          <div className="chapter-filters">
+            <button
+              className={`filter-chip ${selectedChapter === "all" ? "active" : ""}`}
+              onClick={() => setSelectedChapter("all")}
+            >
+              All Chapters
+            </button>
+            <button
+              className={`filter-chip ${selectedChapter === 1 ? "active" : ""}`}
+              onClick={() => setSelectedChapter(1)}
+            >
+              Chapter 1
+            </button>
+            <button
+              className={`filter-chip ${selectedChapter === 2 ? "active" : ""}`}
+              onClick={() => setSelectedChapter(2)}
+            >
+              Chapter 2
+            </button>
+            <button
+              className={`filter-chip ${selectedChapter === 3 ? "active" : ""}`}
+              onClick={() => setSelectedChapter(3)}
+            >
+              Chapter 3
+            </button>
+          </div>
+        </div>
+      </div>
+      <div className="mission-map-grid">
+        {filteredMissions.length === 0 ? (
+          <div className="no-missions-found">
+            <p>No missions found matching your filters.</p>
+          </div>
+        ) : (
+          filteredMissions.map((m) => (
+            <div
+              key={m.id}
+              className={`mission-card ${m.completed ? "completed" : ""} ${!m.unlocked ? "locked" : ""}`}
+              onClick={() => handleMissionClick(m)}
+            >
+              <div className="mission-card-header">
+                <span className="mission-card-chapter">
+                  Chapter {m.chapter} • Mission {m.order}
+                </span>
+                <span className="mission-card-xp">⚡ {m.xpReward} XP</span>
+              </div>
+              <h3 className="mission-card-title">{m.title}</h3>
+              <p className="mission-card-desc">{m.learningGoal}</p>
+              <div className="mission-card-footer">
+                <div className="mission-card-concepts">
+                  {m.conceptsIntroduced.slice(0, 3).map((c) => (
+                    <span key={c} className="concept-tag">
+                      {c}
+                    </span>
+                  ))}
+                </div>
+                <span className={`badge badge-${m.difficulty}`}>
+                  {m.difficulty}
+                </span>
+              </div>
+              {m.completed && (
+                <div className="mission-card-status completed">✓ Completed</div>
+              )}
+              {!m.unlocked && (
+                <div
+                  className="mission-card-status"
+                  style={{ color: "var(--text-muted)" }}
+                >
+                  🔒 Locked
+                </div>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
 }

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -13,6 +13,7 @@ import { getXPProgress, getRankTitle, BADGES } from "../systems/gameEngine";
 import { getAllMissions } from "../systems/missionLoader";
 import { avatars } from "../data/avatars";
 import { logActivity, ACTIVITY_TYPES } from "../systems/activityLogger";
+import { useDocumentTitle } from "../systems/useDocumentTitle";
 
 export default function Profile() {
   const [state, setState] = useState(loadProgress());
@@ -30,6 +31,8 @@ export default function Profile() {
   const xpProgress = getXPProgress(state);
   const rankTitle = getRankTitle(state.level);
   const missions = getAllMissions();
+
+  useDocumentTitle("Profile");
 
   /* ---------------- SAVE PROFILE ---------------- */
   const saveUserProfile = () => {
@@ -66,7 +69,11 @@ export default function Profile() {
       const newState = await importProgress(file);
       setState(newState);
       setImportStatus("✅ Progress imported successfully!");
-      logActivity(ACTIVITY_TYPES.IMPORT, {}, "Imported adventure progress from file");
+      logActivity(
+        ACTIVITY_TYPES.IMPORT,
+        {},
+        "Imported adventure progress from file",
+      );
     } catch {
       setImportStatus("❌ Invalid file — could not import.");
     }
@@ -159,7 +166,10 @@ export default function Profile() {
           {/* NAME */}
           <input
             className="w-full p-2 mb-3 rounded"
-            style={{ backgroundColor: "var(--bg-secondary)", color: "var(--text-primary)" }}
+            style={{
+              backgroundColor: "var(--bg-secondary)",
+              color: "var(--text-primary)",
+            }}
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="Enter name"
@@ -173,7 +183,8 @@ export default function Profile() {
                 onClick={() => setAvatar(a)}
                 className="text-2xl p-2 rounded transition"
                 style={{
-                  backgroundColor: avatar === a ? "var(--cyan-dim)" : "var(--bg-glass)",
+                  backgroundColor:
+                    avatar === a ? "var(--cyan-dim)" : "var(--bg-glass)",
                   transform: avatar === a ? "scale(1.1)" : "none",
                 }}
               >
@@ -246,7 +257,11 @@ export default function Profile() {
           Import
         </button>
 
-        <button className="btn btn-ghost" style={{ color: "var(--red)" }} onClick={handleReset}>
+        <button
+          className="btn btn-ghost"
+          style={{ color: "var(--red)" }}
+          onClick={handleReset}
+        >
           Reset
         </button>
 

--- a/src/pages/SkillTree.jsx
+++ b/src/pages/SkillTree.jsx
@@ -1,34 +1,54 @@
-import React, { useState, useEffect } from 'react';
-import { missions } from '../data/missions';
-import { loadProgress } from '../systems/storage';
-import './SkillTree.css';
+import React, { useState, useEffect } from "react";
+import { missions } from "../data/missions";
+import { loadProgress } from "../systems/storage";
+import { useDocumentTitle } from "../systems/useDocumentTitle";
+import "./SkillTree.css";
 
 const conceptCategories = {
   Core: {
-    title: 'Core Concepts',
-    description: 'Fundamental Soroban building blocks',
-    concepts: ['contract', 'contractimpl', 'Env', 'Symbol']
+    title: "Core Concepts",
+    description: "Fundamental Soroban building blocks",
+    concepts: ["contract", "contractimpl", "Env", "Symbol"],
   },
   Storage: {
-    title: 'Storage & State',
-    description: 'Managing persistent data',
-    concepts: ['storage', 'instance', 'persistent storage', 'set', 'get', 'remove', 'unwrap_or']
+    title: "Storage & State",
+    description: "Managing persistent data",
+    concepts: [
+      "storage",
+      "instance",
+      "persistent storage",
+      "set",
+      "get",
+      "remove",
+      "unwrap_or",
+    ],
   },
   Types: {
-    title: 'Data Types',
-    description: 'Working with different data types',
-    concepts: ['Address', 'Vec', 'Map', 'String', 'i128', 'u32', 'bool']
+    title: "Data Types",
+    description: "Working with different data types",
+    concepts: ["Address", "Vec", "Map", "String", "i128", "u32", "bool"],
   },
   Auth: {
-    title: 'Authorization',
-    description: 'Access control and security',
-    concepts: ['require_auth', 'init pattern', 'admin patterns']
+    title: "Authorization",
+    description: "Access control and security",
+    concepts: ["require_auth", "init pattern", "admin patterns"],
   },
   Advanced: {
-    title: 'Advanced Patterns',
-    description: 'Complex contract patterns',
-    concepts: ['token', 'mint', 'transfer', 'ledger sequence', 'time-lock', 'multi-sig', 'governance pattern', 'conditional panic', 'complex state', 'multiple functions']
-  }
+    title: "Advanced Patterns",
+    description: "Complex contract patterns",
+    concepts: [
+      "token",
+      "mint",
+      "transfer",
+      "ledger sequence",
+      "time-lock",
+      "multi-sig",
+      "governance pattern",
+      "conditional panic",
+      "complex state",
+      "multiple functions",
+    ],
+  },
 };
 
 export default function SkillTree() {
@@ -36,22 +56,24 @@ export default function SkillTree() {
   const [selectedConcept, setSelectedConcept] = useState(null);
   const [hoveredConcept, setHoveredConcept] = useState(null);
 
+  useDocumentTitle("Skill Tree");
+
   useEffect(() => {
     const progress = loadProgress();
     setCompletedMissions(progress.completedMissions || []);
   }, []);
 
   const getConceptStatus = (concept) => {
-    const teachingMission = missions.find(mission => 
-      mission.conceptsIntroduced?.includes(concept)
+    const teachingMission = missions.find((mission) =>
+      mission.conceptsIntroduced?.includes(concept),
     );
-    
-    if (!teachingMission) return { status: 'locked', mission: null };
-    
+
+    if (!teachingMission) return { status: "locked", mission: null };
+
     const isCompleted = completedMissions.includes(teachingMission.id);
     return {
-      status: isCompleted ? 'unlocked' : 'locked',
-      mission: teachingMission
+      status: isCompleted ? "unlocked" : "locked",
+      mission: teachingMission,
     };
   };
 
@@ -65,8 +87,8 @@ export default function SkillTree() {
     const isHovered = hoveredConcept === concept;
     const isSelected = selectedConcept?.concept === concept;
 
-    const nodeClass = `concept-node ${status} ${isHovered ? 'hovered' : ''} ${isSelected ? 'selected' : ''}`;
-    
+    const nodeClass = `concept-node ${status} ${isHovered ? "hovered" : ""} ${isSelected ? "selected" : ""}`;
+
     return (
       <div
         key={concept}
@@ -75,9 +97,7 @@ export default function SkillTree() {
         onMouseEnter={() => setHoveredConcept(concept)}
         onMouseLeave={() => setHoveredConcept(null)}
       >
-        <div className="concept-icon">
-          {status === 'locked' ? '🔒' : '✨'}
-        </div>
+        <div className="concept-icon">{status === "locked" ? "🔒" : "✨"}</div>
         <div className="concept-name">{concept}</div>
         {isHovered && mission && (
           <div className="concept-tooltip">
@@ -91,8 +111,8 @@ export default function SkillTree() {
 
   const renderCategory = (categoryKey, categoryData, index) => {
     const concepts = categoryData.concepts;
-    const unlockedCount = concepts.filter(concept => 
-      getConceptStatus(concept).status === 'unlocked'
+    const unlockedCount = concepts.filter(
+      (concept) => getConceptStatus(concept).status === "unlocked",
     ).length;
     const progress = (unlockedCount / concepts.length) * 100;
 
@@ -102,27 +122,37 @@ export default function SkillTree() {
           <h3 className="category-title">{categoryData.title}</h3>
           <div className="category-progress">
             <div className="progress-bar">
-              <div 
-                className="progress-fill" 
+              <div
+                className="progress-fill"
                 style={{ width: `${progress}%` }}
               />
             </div>
-            <span className="progress-text">{unlockedCount}/{concepts.length}</span>
+            <span className="progress-text">
+              {unlockedCount}/{concepts.length}
+            </span>
           </div>
         </div>
         <p className="category-description">{categoryData.description}</p>
         <div className="concept-grid">
-          {concepts.map((concept, conceptIndex) => 
-            renderConceptNode(concept, index, conceptIndex)
+          {concepts.map((concept, conceptIndex) =>
+            renderConceptNode(concept, index, conceptIndex),
           )}
         </div>
       </div>
     );
   };
 
-  const totalConcepts = Object.values(conceptCategories).reduce((sum, cat) => sum + cat.concepts.length, 0);
-  const totalUnlocked = Object.values(conceptCategories).reduce((sum, cat) => 
-    sum + cat.concepts.filter(concept => getConceptStatus(concept).status === 'unlocked').length, 0
+  const totalConcepts = Object.values(conceptCategories).reduce(
+    (sum, cat) => sum + cat.concepts.length,
+    0,
+  );
+  const totalUnlocked = Object.values(conceptCategories).reduce(
+    (sum, cat) =>
+      sum +
+      cat.concepts.filter(
+        (concept) => getConceptStatus(concept).status === "unlocked",
+      ).length,
+    0,
   );
   const overallProgress = (totalUnlocked / totalConcepts) * 100;
 
@@ -135,8 +165,8 @@ export default function SkillTree() {
         </p>
         <div className="overall-progress">
           <div className="progress-bar large">
-            <div 
-              className="progress-fill" 
+            <div
+              className="progress-fill"
               style={{ width: `${overallProgress}%` }}
             />
           </div>
@@ -147,16 +177,19 @@ export default function SkillTree() {
       </div>
 
       <div className="skill-categories">
-        {Object.entries(conceptCategories).map(([key, data], index) => 
-          renderCategory(key, data, index)
+        {Object.entries(conceptCategories).map(([key, data], index) =>
+          renderCategory(key, data, index),
         )}
       </div>
 
       {selectedConcept && (
-        <div className="concept-detail-modal" onClick={() => setSelectedConcept(null)}>
+        <div
+          className="concept-detail-modal"
+          onClick={() => setSelectedConcept(null)}
+        >
           <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-            <button 
-              className="modal-close" 
+            <button
+              className="modal-close"
               onClick={() => setSelectedConcept(null)}
             >
               ×
@@ -165,9 +198,16 @@ export default function SkillTree() {
             {selectedConcept.mission ? (
               <div className="mission-info">
                 <h4>Taught in: {selectedConcept.mission.title}</h4>
-                <p><strong>Chapter:</strong> {selectedConcept.mission.chapter}</p>
-                <p><strong>Difficulty:</strong> {selectedConcept.mission.difficulty}</p>
-                <p><strong>XP Reward:</strong> {selectedConcept.mission.xpReward}</p>
+                <p>
+                  <strong>Chapter:</strong> {selectedConcept.mission.chapter}
+                </p>
+                <p>
+                  <strong>Difficulty:</strong>{" "}
+                  {selectedConcept.mission.difficulty}
+                </p>
+                <p>
+                  <strong>XP Reward:</strong> {selectedConcept.mission.xpReward}
+                </p>
                 <div className="mission-learning-goal">
                   <strong>Learning Goal:</strong>
                   <p>{selectedConcept.mission.learningGoal}</p>
@@ -180,7 +220,7 @@ export default function SkillTree() {
                   )}
                 </div>
                 {!completedMissions.includes(selectedConcept.mission.id) && (
-                  <a 
+                  <a
                     href={`/mission/${selectedConcept.mission.id}`}
                     className="start-mission-btn"
                   >

--- a/src/systems/useDocumentTitle.js
+++ b/src/systems/useDocumentTitle.js
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+const BASE_TITLE = 'Soroban Quest';
+
+/**
+ * Custom hook to dynamically update the document title
+ * @param {string} title - The page-specific title (without the base title)
+ */
+export function useDocumentTitle(title) {
+  useEffect(() => {
+    if (title) {
+      document.title = `${title} | ${BASE_TITLE}`;
+    } else {
+      document.title = BASE_TITLE;
+    }
+
+    // Cleanup: restore base title when component unmounts
+    return () => {
+      document.title = BASE_TITLE;
+    };
+  }, [title]);
+}


### PR DESCRIPTION
Add dynamic document titles per route

## What does this PR do?
## PR Description

This PR introduces dynamic document titles across the application using a reusable `useDocumentTitle` custom hook.

Previously, the app used a single static title defined in `index.html`, causing every route to display the same browser tab title regardless of the active page. This update improves user experience, navigation clarity, and SEO by updating the document title dynamically based on the current route.

The implementation includes:

* Creating a reusable `useDocumentTitle(title)` hook in `src/systems/`
* Integrating the hook into all major page components
* Supporting dynamic mission titles for mission detail pages
* Providing a fallback base title when no custom title is supplied

Updated routes now display descriptive titles such as:

* `Home | Soroban Quest`
* `Mission Map | Soroban Quest`
* `Profile | Soroban Quest`
* `Campaigns | Soroban Quest`


## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Content (new mission or educational material)
- [ ] Documentation
- [ ] Refactor

## Testing checklist
- [x] `npm run build` passes
- [ ] `npm run lint` passes (if available)
- [x] Tested locally in the browser
- [ ] All existing pages still work correctly
- [ ] Screenshots attached (if UI change)

Closes #92
