### PR TITLE
closes #107 -- feat: internationalization (i18n) with language selector 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,11 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { ToastProvider } from "./systems/ToastContext";
 import "./systems/Toast.css";
 
+// 3. Import Language Provider
+//    Placed OUTSIDE the ErrorBoundary so the boundary's fallback
+//    UI can still call useTranslation() when something in the tree throws.
+import { LanguageProvider } from "./i18n";
+
 export default function App() {
 
   useEffect(() => {
@@ -38,26 +43,27 @@ export default function App() {
 
 
   return (
-    <ErrorBoundary>
-      {/* 3. Wraped everything in ToastProvider */}
-      <ToastProvider>
-        <div className="app">
-          <Navbar />
-          <main className="main-content">
-            <Routes>
-              <Route path="/" element={<Home />} />
-              <Route path="/missions" element={<MissionMap />} />
-              <Route path="/campaigns" element={<Campaigns />} />
-              <Route path="/mission/:missionId" element={<MissionDetail />} />
-              <Route path="/profile" element={<Profile />} />
-              <Route path="/journal" element={<Journal />} />
-              <Route path="/skills" element={<SkillTree />} />
-              <Route path="*" element={<NotFound />} />
-            </Routes>
-          </main>
-          <Footer />
-        </div>
-      </ToastProvider>
-    </ErrorBoundary>
+    <LanguageProvider>
+      <ErrorBoundary>
+        <ToastProvider>
+          <div className="app">
+            <Navbar />
+            <main className="main-content">
+              <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/missions" element={<MissionMap />} />
+                <Route path="/campaigns" element={<Campaigns />} />
+                <Route path="/mission/:missionId" element={<MissionDetail />} />
+                <Route path="/profile" element={<Profile />} />
+                <Route path="/journal" element={<Journal />} />
+                <Route path="/skills" element={<SkillTree />} />
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </main>
+            <Footer />
+          </div>
+        </ToastProvider>
+      </ErrorBoundary>
+    </LanguageProvider>
   );
 }

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,5 +1,70 @@
 import React from "react";
+import { useTranslation } from "../i18n/useTranslation";
 import "./ErrorBoundary.css";
+
+/* ---------- Functional fallback subcomponents ---------- */
+/* They live inside the LanguageProvider tree (the provider is above
+   the ErrorBoundary in App.jsx), so they can safely use useTranslation. */
+
+function GenericErrorFallback() {
+  const { t } = useTranslation();
+  return (
+    <div className="error-boundary-overlay">
+      <div className="error-icon">⚠️</div>
+      <h1 className="error-title">{t("errorBoundary.generic.title")}</h1>
+      <p className="error-text">{t("errorBoundary.generic.body")}</p>
+      <div className="error-button-group">
+        <button
+          className="btn-reload"
+          onClick={() => window.location.reload()}
+        >
+          {t("errorBoundary.generic.reload")}
+        </button>
+        <a
+          className="btn-report"
+          href="https://github.com/JafetCHVDev/soroban-quest/issues"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {t("errorBoundary.generic.report")}
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function EditorErrorFallback() {
+  const { t } = useTranslation();
+  return (
+    <div className="editor-fallback">
+      <p style={{ color: "#f87171" }}>{t("errorBoundary.editor.body")}</p>
+      <button
+        className="btn-reload"
+        style={{ scale: "0.8" }}
+        onClick={() => window.location.reload()}
+      >
+        {t("errorBoundary.editor.reset")}
+      </button>
+    </div>
+  );
+}
+
+function MissionErrorFallback() {
+  const { t } = useTranslation();
+  return (
+    <div
+      className="error-boundary-overlay"
+      style={{ minHeight: "auto", padding: "40px" }}
+    >
+      <h3 style={{ color: "#6366f1" }}>{t("errorBoundary.mission.title")}</h3>
+      <button onClick={() => window.location.reload()}>
+        {t("errorBoundary.mission.retry")}
+      </button>
+    </div>
+  );
+}
+
+/* ---------- Class boundaries ---------- */
 
 /**
  * 1. Generic Error Boundary
@@ -20,31 +85,7 @@ export class ErrorBoundary extends React.Component {
 
   render() {
     if (this.state.hasError) {
-      return (
-        <div className="error-boundary-overlay">
-          <div className="error-icon">⚠️</div>
-          <h1 className="error-title">Something went wrong</h1>
-          <p className="error-text">
-            The quest encountered a runtime error. Check the console for
-            details.
-          </p>
-          <div className="error-button-group">
-            <button
-              className="btn-reload"
-              onClick={() => window.location.reload()}
-            >
-              Reload
-            </button>
-            <a
-              className="btn-report"
-              href="https://github.com/JafetCHVDev/soroban-quest/issues"
-              target="_blank"
-            >
-              Report Issue
-            </a>
-          </div>
-        </div>
-      );
+      return <GenericErrorFallback />;
     }
     return this.props.children;
   }
@@ -65,18 +106,7 @@ export class EditorErrorBoundary extends React.Component {
 
   render() {
     if (this.state.hasError) {
-      return (
-        <div className="editor-fallback">
-          <p style={{ color: "#f87171" }}>Editor failed to load</p>
-          <button
-            className="btn-reload"
-            style={{ scale: "0.8" }}
-            onClick={() => window.location.reload()}
-          >
-            Reset Editor
-          </button>
-        </div>
-      );
+      return <EditorErrorFallback />;
     }
     return this.props.children;
   }
@@ -97,15 +127,7 @@ export class MissionErrorBoundary extends React.Component {
 
   render() {
     if (this.state.hasError) {
-      return (
-        <div
-          className="error-boundary-overlay"
-          style={{ minHeight: "auto", padding: "40px" }}
-        >
-          <h3 style={{ color: "#6366f1" }}>Mission unavailable</h3>
-          <button onClick={() => window.location.reload()}>Try again</button>
-        </div>
-      );
+      return <MissionErrorFallback />;
     }
     return this.props.children;
   }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,40 +1,43 @@
 import React from "react";
+import { useTranslation } from "../i18n/useTranslation";
 
 export default function Footer() {
+  const { t } = useTranslation();
+
   return (
     <footer className="footer">
       <div className="footer-content">
         <div className="footer-section">
-          <h4>Platform</h4>
+          <h4>{t("footer.platform.heading")}</h4>
           <ul>
-            <li><a href="/">Home</a></li>
-            <li><a href="/missions">Missions</a></li>
-            <li><a href="/profile">Profile</a></li>
-            <li><a href="/glossary">Glossary</a></li>
+            <li><a href="/">{t("footer.platform.home")}</a></li>
+            <li><a href="/missions">{t("footer.platform.missions")}</a></li>
+            <li><a href="/profile">{t("footer.platform.profile")}</a></li>
+            <li><a href="/glossary">{t("footer.platform.glossary")}</a></li>
           </ul>
         </div>
 
         <div className="footer-section">
-          <h4>Resources</h4>
+          <h4>{t("footer.resources.heading")}</h4>
           <ul>
-            <li><a href="https://soroban.stellar.org" target="_blank" rel="noopener">Soroban Docs</a></li>
-            <li><a href="https://stellar.org/developers" target="_blank" rel="noopener">Stellar SDK</a></li>
-            <li><a href="https://github.com/JafetCHVDev/soroban-quest" target="_blank" rel="noopener">GitHub</a></li>
+            <li><a href="https://soroban.stellar.org" target="_blank" rel="noopener">{t("footer.resources.docs")}</a></li>
+            <li><a href="https://stellar.org/developers" target="_blank" rel="noopener">{t("footer.resources.sdk")}</a></li>
+            <li><a href="https://github.com/JafetCHVDev/soroban-quest" target="_blank" rel="noopener">{t("footer.resources.github")}</a></li>
           </ul>
         </div>
 
         <div className="footer-section">
-          <h4>Community</h4>
+          <h4>{t("footer.community.heading")}</h4>
           <ul>
-            <li><a href="#" target="_blank" rel="noopener">Discord</a></li>
-            <li><a href="#" target="_blank" rel="noopener">Telegram</a></li>
+            <li><a href="#" target="_blank" rel="noopener">{t("footer.community.discord")}</a></li>
+            <li><a href="#" target="_blank" rel="noopener">{t("footer.community.telegram")}</a></li>
           </ul>
         </div>
       </div>
 
       <div className="footer-credits">
-        <p>Built for the Stellar ecosystem</p>
-        <p>MIT License</p>
+        <p>{t("footer.credits.tagline")}</p>
+        <p>{t("footer.credits.license")}</p>
       </div>
     </footer>
   );

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,12 +1,17 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { Menu, X, Sun, Moon } from "lucide-react";
+import { Menu, X, Sun, Moon, Globe, ChevronDown } from "lucide-react";
 import { loadProfile } from "../systems/storage";
+import { useTranslation } from "../i18n/useTranslation";
 
 export default function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
+  const [langOpen, setLangOpen] = useState(false);
   const location = useLocation();
   const profile = loadProfile();
+  const langRef = useRef(null);
+
+  const { t, language, setLanguage, languages } = useTranslation();
 
   const [theme, setTheme] = useState(() => {
     return (
@@ -22,11 +27,89 @@ export default function Navbar() {
     localStorage.setItem("soroban_quest_theme", theme);
   }, [theme]);
 
+  // Close the language dropdown on outside click or Escape
+  useEffect(() => {
+    if (!langOpen) return;
+    const onClick = (e) => {
+      if (langRef.current && !langRef.current.contains(e.target)) {
+        setLangOpen(false);
+      }
+    };
+    const onKey = (e) => {
+      if (e.key === "Escape") setLangOpen(false);
+    };
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [langOpen]);
+
   const toggleTheme = () => {
     setTheme((prev) => (prev === "light" ? "dark" : "light"));
   };
 
+  const handleLanguageChange = (code) => {
+    setLanguage(code);
+    setLangOpen(false);
+  };
+
   const isActive = (path) => (location.pathname === path ? "active" : "");
+
+  // Reusable language selector — renders the same control on desktop & mobile
+  const LanguageSelector = ({ idSuffix = "desktop" }) => {
+    const currentLang =
+      languages.find((l) => l.code === language) || languages[0];
+
+    return (
+      <div className="language-selector" ref={idSuffix === "desktop" ? langRef : null}>
+        <button
+          type="button"
+          className="btn-ghost language-selector-trigger"
+          aria-haspopup="listbox"
+          aria-expanded={langOpen}
+          aria-label={t("common.selectLanguage")}
+          onClick={() => setLangOpen((v) => !v)}
+        >
+          <Globe size={18} />
+          <span className="language-selector-code">
+            {currentLang.code.toUpperCase()}
+          </span>
+          <ChevronDown size={14} aria-hidden="true" />
+        </button>
+
+        {langOpen && (
+          <ul
+            className="language-selector-menu"
+            role="listbox"
+            aria-label={t("common.selectLanguage")}
+          >
+            {languages.map((lang) => (
+              <li key={lang.code}>
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={lang.code === language}
+                  className={`language-selector-option ${
+                    lang.code === language ? "active" : ""
+                  }`}
+                  onClick={() => handleLanguageChange(lang.code)}
+                >
+                  <span className="language-selector-option-code">
+                    {lang.code.toUpperCase()}
+                  </span>
+                  <span className="language-selector-option-name">
+                    {lang.name}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    );
+  };
 
   return (
     <nav className="navbar">
@@ -39,38 +122,40 @@ export default function Navbar() {
       <ul className="navbar-links">
         <li>
           <Link to="/" className={isActive("/")}>
-            Home
+            {t("navbar.home")}
           </Link>
         </li>
         <li>
           <Link to="/campaigns" className={isActive("/campaigns")}>
-            Campaigns
+            {t("navbar.campaigns")}
           </Link>
         </li>
         <li>
           <Link to="/missions" className={isActive("/missions")}>
-            Missions
+            {t("navbar.missions")}
           </Link>
         </li>
         <li>
           <Link to="/profile" className={isActive("/profile")}>
-            Profile
+            {t("navbar.profile")}
           </Link>
         </li>
         <li>
           <Link to="/journal" className={isActive("/journal")}>
-            Journal
+            {t("navbar.journal")}
           </Link>
         </li>
       </ul>
 
-      {/* PROFILE DISPLAY & THEME TOGGLE (DESKTOP) */}
+      {/* PROFILE DISPLAY, LANGUAGE & THEME TOGGLE (DESKTOP) */}
       <div className="navbar-stats">
+        <LanguageSelector idSuffix="desktop" />
+
         <button
           onClick={toggleTheme}
           className="btn-ghost"
           style={{ padding: "0.5rem", borderRadius: "50%" }}
-          aria-label="Toggle theme"
+          aria-label={t("common.toggleTheme")}
         >
           {theme === "light" ? <Moon size={20} /> : <Sun size={20} />}
         </button>
@@ -89,28 +174,30 @@ export default function Navbar() {
       {/* MOBILE */}
       <div className={`mobile-menu ${isOpen ? "open" : ""}`}>
         <Link to="/" onClick={() => setIsOpen(false)}>
-          Home
+          {t("navbar.home")}
         </Link>
         <Link to="/campaigns" onClick={() => setIsOpen(false)}>
-          Campaigns
+          {t("navbar.campaigns")}
         </Link>
         <Link to="/missions" onClick={() => setIsOpen(false)}>
-          Missions
+          {t("navbar.missions")}
         </Link>
         <Link to="/profile" onClick={() => setIsOpen(false)}>
-          Profile
+          {t("navbar.profile")}
         </Link>
         <Link to="/journal" onClick={() => setIsOpen(false)}>
-          Journal
+          {t("navbar.journal")}
         </Link>
 
         {/* MOBILE EXTRAS */}
         <div className="mobile-stats">
+          <LanguageSelector idSuffix="mobile" />
+
           <button
             onClick={toggleTheme}
             className="btn-ghost"
             style={{ padding: "0.5rem", borderRadius: "50%" }}
-            aria-label="Toggle theme"
+            aria-label={t("common.toggleTheme")}
           >
             {theme === "light" ? <Moon size={20} /> : <Sun size={20} />}
           </button>

--- a/src/data/campaigns.js
+++ b/src/data/campaigns.js
@@ -1,16 +1,26 @@
 /* ==========================================
    Campaign System — Grouped mission chapters
    with lore, progression gates, hero images
+
+   Phase 3 (i18n): Language-neutral fields (id, heroImage,
+   chapterNumber, missionIds, requiredLevel, color) live at the top
+   level. Localizable fields (title, description, lore) live under
+   `i18n[locale]`. Use `localizeCampaign(campaign, lang)` to get a
+   flat, render-ready object.
    ========================================== */
 
 import { missions } from './missions.js';
 
+export const DEFAULT_CAMPAIGN_LANG = 'en';
+
 export const campaigns = [
   {
     id: 'chapter-1-awakening',
-    title: 'Chapter 1: The Awakening',
-    description: 'Master your first Soroban contracts. Forge your path as a Stellar Guardian.',
-    lore: `# 🌌 Chapter 1: The Awakening
+    i18n: {
+      en: {
+        title: 'Chapter 1: The Awakening',
+        description: 'Master your first Soroban contracts. Forge your path as a Stellar Guardian.',
+        lore: `# 🌌 Chapter 1: The Awakening
 
 You stand at the gates of the **Stellar Citadel**, orbiting the edge of known space. The ancient **Guardians of Soroban** have sensed your arrival.
 
@@ -21,6 +31,23 @@ You stand at the gates of the **Stellar Citadel**, orbiting the edge of known sp
 Complete these foundational contracts to unlock **Chapter 2: Vault of Memory**.
 
 **0/2 missions** • **Level 1 required**`,
+      },
+      es: {
+        title: 'Capítulo 1: El Despertar',
+        description: 'Domina tus primeros contratos de Soroban. Forja tu camino como Guardián Estelar.',
+        lore: `# 🌌 Capítulo 1: El Despertar
+
+Te encuentras ante las puertas de la **Ciudadela Estelar**, orbitando el confín del espacio conocido. Los antiguos **Guardianes de Soroban** han percibido tu llegada.
+
+*"Otro buscador,"* susurra el Guardián Anciano. *"La blockchain llama a quienes tienen el código para responder."*
+
+## Tu Destino Aguarda
+
+Completa estos contratos fundamentales para desbloquear el **Capítulo 2: Bóveda de la Memoria**.
+
+**0/2 misiones** • **Nivel 1 requerido**`,
+      },
+    },
     heroImage: 'linear-gradient(135deg, #06d6a0 0%, #8b5cf6 50%, #f59e0b 100%)',
     chapterNumber: 1,
     missionIds: ['hello-soroban', 'greetings-protocol'],
@@ -29,9 +56,11 @@ Complete these foundational contracts to unlock **Chapter 2: Vault of Memory**.
   },
   {
     id: 'chapter-2-memory',
-    title: 'Chapter 2: Vault of Memory', 
-    description: 'Unlock persistent storage and access control. Memory defines true power.',
-    lore: `# 🔐 Chapter 2: Vault of Memory
+    i18n: {
+      en: {
+        title: 'Chapter 2: Vault of Memory',
+        description: 'Unlock persistent storage and access control. Memory defines true power.',
+        lore: `# 🔐 Chapter 2: Vault of Memory
 
 The **Signal Tower** fades behind you. You descend into the **Vault of Memory**, where ancient wisdom persists across eons.
 
@@ -42,6 +71,23 @@ The **Signal Tower** fades behind you. You descend into the **Vault of Memory**,
 Master state management to access **Chapter 3: Token Forge**.
 
 **0/2 missions** • **Level 3 required**`,
+      },
+      es: {
+        title: 'Capítulo 2: Bóveda de la Memoria',
+        description: 'Desbloquea el almacenamiento persistente y el control de acceso. La memoria define el verdadero poder.',
+        lore: `# 🔐 Capítulo 2: Bóveda de la Memoria
+
+La **Torre de Señales** se desvanece tras de ti. Desciendes a la **Bóveda de la Memoria**, donde la sabiduría ancestral perdura a través de eones.
+
+*"Un contrato sin memoria es un pensamiento fugaz,"* murmura el Guardián de la Bóveda. *"Para perdurar, debes almacenar y proteger."*
+
+## La Segunda Prueba
+
+Domina la gestión de estado para acceder al **Capítulo 3: Forja de Tokens**.
+
+**0/2 misiones** • **Nivel 3 requerido**`,
+      },
+    },
     heroImage: 'linear-gradient(135deg, #8b5cf6 0%, #f59e0b 50%, #ef4444 100%)',
     chapterNumber: 2,
     missionIds: ['counter-vault', 'guardian-ledger'],
@@ -50,9 +96,11 @@ Master state management to access **Chapter 3: Token Forge**.
   },
   {
     id: 'chapter-3-forge',
-    title: 'Chapter 3: Token Forge',
-    description: 'Mint tokens, master time-locks, govern with multi-sig. Become the Master Guardian.',
-    lore: `# ⚒️ Chapter 3: Token Forge
+    i18n: {
+      en: {
+        title: 'Chapter 3: Token Forge',
+        description: 'Mint tokens, master time-locks, govern with multi-sig. Become the Master Guardian.',
+        lore: `# ⚒️ Chapter 3: Token Forge
 
 The **Chrono Gate** hums with power. You enter the **Token Forge** — heart of the Stellar economy.
 
@@ -63,6 +111,23 @@ The **Chrono Gate** hums with power. You enter the **Token Forge** — heart of 
 Complete the Token Forge to earn **Legendary Guardian** status.
 
 **0/3 missions** • **Level 5 required**`,
+      },
+      es: {
+        title: 'Capítulo 3: Forja de Tokens',
+        description: 'Acuña tokens, domina los cerrojos temporales, gobierna con multifirma. Conviértete en Guardián Maestro.',
+        lore: `# ⚒️ Capítulo 3: Forja de Tokens
+
+La **Puerta del Tiempo** vibra con poder. Entras en la **Forja de Tokens** — el corazón de la economía Stellar.
+
+*"La verdadera maestría crea valor que perdura,"* declara el Maestro Forjador. *"Tokens, tiempo, confianza — fórjalos todos."*
+
+## Desafío Final
+
+Completa la Forja de Tokens para obtener el estatus de **Guardián Legendario**.
+
+**0/3 misiones** • **Nivel 5 requerido**`,
+      },
+    },
     heroImage: 'linear-gradient(135deg, #f59e0b 0%, #ef4444 50%, #06d6a0 100%)',
     chapterNumber: 3,
     missionIds: ['token-forge', 'time-lock', 'multi-party-pact'],
@@ -71,12 +136,48 @@ Complete the Token Forge to earn **Legendary Guardian** status.
   }
 ];
 
+/* ==========================================
+   Localization helpers
+   ========================================== */
+
+/**
+ * Returns a flat, render-ready campaign object for the given language.
+ * Localizable fields (title, description, lore) resolve from
+ * `campaign.i18n[lang]`, falling back to English, then any legacy
+ * top-level field. The `i18n` block is omitted from the result.
+ */
+export function localizeCampaign(campaign, lang = DEFAULT_CAMPAIGN_LANG) {
+  if (!campaign) return campaign;
+
+  const { i18n, ...neutral } = campaign;
+  const locale = (i18n && (i18n[lang] || i18n[DEFAULT_CAMPAIGN_LANG])) || {};
+  const fallback = (i18n && i18n[DEFAULT_CAMPAIGN_LANG]) || {};
+
+  const pick = (field) =>
+    locale[field] != null
+      ? locale[field]
+      : fallback[field] != null
+      ? fallback[field]
+      : neutral[field];
+
+  return {
+    ...neutral,
+    title: pick('title'),
+    description: pick('description'),
+    lore: pick('lore'),
+  };
+}
+
+/** Localizes an array of campaigns. */
+export function localizeCampaigns(list, lang = DEFAULT_CAMPAIGN_LANG) {
+  return (list || []).map((c) => localizeCampaign(c, lang));
+}
+
 // Helper: Get campaign progress from completedMissions array
 export function getCampaignProgress(campaignId, completedMissions) {
   const campaign = campaigns.find(c => c.id === campaignId);
   if (!campaign) return { completed: 0, total: 0 };
-  
+
   const completed = campaign.missionIds.filter(id => completedMissions.includes(id)).length;
   return { completed, total: campaign.missionIds.length, percentage: (completed / campaign.missionIds.length) * 100 };
 }
-

--- a/src/data/missions.js
+++ b/src/data/missions.js
@@ -1,16 +1,29 @@
 /* ==========================================
    Mission Data — 7 progressive Soroban missions
+
+   Phase 3 (i18n): Language-neutral fields (id, chapter, order,
+   difficulty, xpReward, template, solution, checks,
+   conceptsIntroduced) live at the top level. Localizable fields
+   (title, story, learningGoal, hints) live under `i18n[locale]`.
+
+   Use `localizeMission(mission, lang)` to get a flat, render-ready
+   object whose title/story/learningGoal/hints resolve to the active
+   language (falling back to English when a translation is missing).
    ========================================== */
+
+export const DEFAULT_MISSION_LANG = 'en';
 
 export const missions = [
     {
         id: 'hello-soroban',
-        title: 'The First Contract',
         chapter: 1,
         order: 1,
         difficulty: 'beginner',
         xpReward: 100,
-        story: `# 🌌 The Awakening
+        i18n: {
+            en: {
+                title: 'The First Contract',
+                story: `# 🌌 The Awakening
 
 You stand at the gates of the **Stellar Citadel**, a shimmering fortress orbiting the edge of known space. The Guardians of Soroban have sensed your arrival.
 
@@ -37,7 +50,50 @@ Symbol               // A small, efficient string type
 \`\`\`
 
 Complete the code template to pass all checks. The Guardians await your first contract! ⚔️`,
-        learningGoal: 'Create your first Soroban smart contract with a hello function',
+                learningGoal: 'Create your first Soroban smart contract with a hello function',
+                hints: [
+                    'Start with `pub fn hello(env: Env, to: Symbol) -> Vec<Symbol>`',
+                    'Use the `vec![]` macro with `&env` as the first argument',
+                    'The full return line: `vec![&env, symbol_short!("Hello"), to]`',
+                ],
+            },
+            es: {
+                title: 'El Primer Contrato',
+                story: `# 🌌 El Despertar
+
+Te encuentras ante las puertas de la **Ciudadela Estelar**, una fortaleza reluciente que orbita el confín del espacio conocido. Los Guardianes de Soroban han percibido tu llegada.
+
+*"Otro buscador,"* susurra el Guardián Anciano. *"Para demostrar tu valía, debes forjar tu primer contrato inteligente."*
+
+## Tu Misión
+
+Crea tu primer contrato inteligente de Soroban — un contrato simple con una función \`hello\` que recibe un nombre y devuelve un saludo.
+
+## Lo Que Aprenderás
+
+- Los atributos \`#[contract]\` y \`#[contractimpl]\`
+- El tipo \`Env\` — tu puerta de entrada a la blockchain
+- El tipo \`Symbol\` para valores tipo cadena
+- Cómo devolver un \`Vec<Symbol>\`
+
+## Conceptos Clave
+
+\`\`\`rust
+#[contract]          // Marca tu struct como un contrato
+#[contractimpl]      // Contiene los métodos del contrato
+Env                  // El entorno de ejecución
+Symbol               // Un tipo de cadena pequeño y eficiente
+\`\`\`
+
+Completa la plantilla de código para pasar todas las verificaciones. ¡Los Guardianes esperan tu primer contrato! ⚔️`,
+                learningGoal: 'Crea tu primer contrato inteligente de Soroban con una función hello',
+                hints: [
+                    'Comienza con `pub fn hello(env: Env, to: Symbol) -> Vec<Symbol>`',
+                    'Usa la macro `vec![]` con `&env` como primer argumento',
+                    'La línea de retorno completa: `vec![&env, symbol_short!("Hello"), to]`',
+                ],
+            },
+        },
         template: `#![no_std]
 use soroban_sdk::{contract, contractimpl, symbol_short, vec, Env, Symbol, Vec};
 
@@ -73,22 +129,19 @@ impl HelloContract {
             { type: 'uses_type', typeName: 'Env', message: 'Must use the Env type' },
             { type: 'contains_pattern', pattern: 'vec![', message: 'Use vec![] macro to create the return vector', description: 'vec![] macro usage' },
         ],
-        hints: [
-            'Start with `pub fn hello(env: Env, to: Symbol) -> Vec<Symbol>`',
-            'Use the `vec![]` macro with `&env` as the first argument',
-            'The full return line: `vec![&env, symbol_short!("Hello"), to]`',
-        ],
         conceptsIntroduced: ['contract', 'contractimpl', 'Env', 'Symbol', 'Vec'],
     },
 
     {
         id: 'greetings-protocol',
-        title: 'Greetings Protocol',
         chapter: 1,
         order: 2,
         difficulty: 'beginner',
         xpReward: 150,
-        story: `# 📡 The Signal Tower
+        i18n: {
+            en: {
+                title: 'Greetings Protocol',
+                story: `# 📡 The Signal Tower
 
 The first gate is open. You advance to the **Signal Tower**, where messages ripple across the Stellar network.
 
@@ -114,7 +167,49 @@ String              // Full string type in Soroban
 symbol_short!()     // Create a Symbol from a short literal
 u32                 // Unsigned 32-bit integer
 \`\`\``,
-        learningGoal: 'Build a multi-function contract with different return types',
+                learningGoal: 'Build a multi-function contract with different return types',
+                hints: [
+                    'The greet function signature: `pub fn greet(env: Env, name: Symbol) -> Vec<Symbol>`',
+                    'For count_chars: `pub fn count_chars(env: Env, text: String) -> u32`',
+                    'Use `text.len()` to get the string length',
+                ],
+            },
+            es: {
+                title: 'Protocolo de Saludos',
+                story: `# 📡 La Torre de Señales
+
+La primera puerta está abierta. Avanzas hacia la **Torre de Señales**, donde los mensajes se propagan a través de la red Stellar.
+
+*"La comunicación es poder,"* dice el Guardián de la Torre. *"Tu contrato debe aprender a gestionar datos — aceptar entradas y devolver respuestas estructuradas."*
+
+## Tu Misión
+
+Construye un contrato con varias funciones:
+- \`greet\` — recibe un nombre y devuelve un saludo personalizado
+- \`count_chars\` — recibe una cadena y devuelve su longitud como u32
+
+## Lo Que Aprenderás
+
+- Varias funciones en un solo contrato
+- Trabajar con el tipo \`String\` en Soroban
+- Devolver distintos tipos desde las funciones
+- La macro \`symbol_short!\`
+
+## Conceptos Clave
+
+\`\`\`rust
+String              // Tipo de cadena completo en Soroban
+symbol_short!()     // Crea un Symbol a partir de un literal corto
+u32                 // Entero sin signo de 32 bits
+\`\`\``,
+                learningGoal: 'Construye un contrato multifunción con distintos tipos de retorno',
+                hints: [
+                    'La firma de la función greet: `pub fn greet(env: Env, name: Symbol) -> Vec<Symbol>`',
+                    'Para count_chars: `pub fn count_chars(env: Env, text: String) -> u32`',
+                    'Usa `text.len()` para obtener la longitud de la cadena',
+                ],
+            },
+        },
         template: `#![no_std]
 use soroban_sdk::{contract, contractimpl, symbol_short, vec, Env, Symbol, Vec, String};
 
@@ -158,22 +253,19 @@ impl GreetingContract {
             { type: 'returns_type', function: 'count_chars', returnType: 'u32', message: "'count_chars' should return u32" },
             { type: 'uses_type', typeName: 'String', message: 'Must use the String type for count_chars' },
         ],
-        hints: [
-            'The greet function signature: `pub fn greet(env: Env, name: Symbol) -> Vec<Symbol>`',
-            'For count_chars: `pub fn count_chars(env: Env, text: String) -> u32`',
-            'Use `text.len()` to get the string length',
-        ],
         conceptsIntroduced: ['String', 'multiple functions', 'u32'],
     },
 
     {
         id: 'counter-vault',
-        title: 'The Counter Vault',
         chapter: 2,
         order: 3,
         difficulty: 'beginner',
         xpReward: 200,
-        story: `# 🔐 The Vault of Memory
+        i18n: {
+            en: {
+                title: 'The Counter Vault',
+                story: `# 🔐 The Vault of Memory
 
 You descend into the **Vault of Memory**, where the ancients stored wisdom that persists across time.
 
@@ -199,7 +291,49 @@ env.storage().instance().set(&key, &value)  // Write
 env.storage().instance().get(&key)          // Read (returns Option)
 .unwrap_or(default)                         // Default if None
 \`\`\``,
-        learningGoal: 'Use persistent storage to create a stateful counter contract',
+                learningGoal: 'Use persistent storage to create a stateful counter contract',
+                hints: [
+                    'Use `env.storage().instance().get(&COUNTER)` to read the count',
+                    'Use `.unwrap_or(0)` to default to 0 when no value exists',
+                    'Use `env.storage().instance().set(&COUNTER, &new_count)` to store the new count',
+                ],
+            },
+            es: {
+                title: 'La Bóveda Contadora',
+                story: `# 🔐 La Bóveda de la Memoria
+
+Desciendes a la **Bóveda de la Memoria**, donde los antiguos guardaron la sabiduría que perdura a través del tiempo.
+
+*"Un contrato sin memoria es como un ser consciente sin alma,"* murmura el Guardián de la Bóveda. *"Aprende a almacenar y recuperar — a recordar."*
+
+## Tu Misión
+
+Crea un contrato contador que conserva su valor:
+- \`increment\` — incrementa el contador en 1
+- \`get_count\` — devuelve el conteo actual
+
+## Lo Que Aprenderás
+
+- **Almacenamiento persistente** con \`env.storage().instance()\`
+- Leer y escribir estado
+- El patrón de clave \`Symbol\` para el almacenamiento
+- Valores por defecto con \`.unwrap_or()\`
+
+## Conceptos Clave
+
+\`\`\`rust
+env.storage().instance().set(&key, &value)  // Escribir
+env.storage().instance().get(&key)          // Leer (devuelve Option)
+.unwrap_or(default)                         // Valor por defecto si es None
+\`\`\``,
+                learningGoal: 'Usa almacenamiento persistente para crear un contrato contador con estado',
+                hints: [
+                    'Usa `env.storage().instance().get(&COUNTER)` para leer el conteo',
+                    'Usa `.unwrap_or(0)` para devolver 0 por defecto cuando no existe un valor',
+                    'Usa `env.storage().instance().set(&COUNTER, &new_count)` para guardar el nuevo conteo',
+                ],
+            },
+        },
         template: `#![no_std]
 use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
 
@@ -251,22 +385,19 @@ impl CounterContract {
             { type: 'storage_operation', operation: 'set', message: 'Must use storage set to persist the count' },
             { type: 'storage_operation', operation: 'get', message: 'Must use storage get to read the count' },
         ],
-        hints: [
-            'Use `env.storage().instance().get(&COUNTER)` to read the count',
-            'Use `.unwrap_or(0)` to default to 0 when no value exists',
-            'Use `env.storage().instance().set(&COUNTER, &new_count)` to store the new count',
-        ],
         conceptsIntroduced: ['storage', 'instance', 'set', 'get', 'unwrap_or'],
     },
 
     {
         id: 'guardian-ledger',
-        title: 'Guardian Ledger',
         chapter: 2,
         order: 4,
         difficulty: 'intermediate',
         xpReward: 250,
-        story: `# 📋 The Guardian Ledger
+        i18n: {
+            en: {
+                title: 'Guardian Ledger',
+                story: `# 📋 The Guardian Ledger
 
 The Council Chamber glows with ancient light. Before you lies the **Guardian Ledger** — a registry of all who have proven themselves.
 
@@ -293,7 +424,50 @@ Address                     // Represents an account/identity
 address.require_auth()      // Ensures the caller is authorized
 Map<Address, Symbol>        // Key-value mapping
 \`\`\``,
-        learningGoal: 'Implement access control with Address and require_auth',
+                learningGoal: 'Implement access control with Address and require_auth',
+                hints: [
+                    'The init function stores the admin: `env.storage().instance().set(&ADMIN, &admin)`',
+                    'In register, call `who.require_auth()` before storing',
+                    'Store with: `env.storage().instance().set(&who, &name)`',
+                ],
+            },
+            es: {
+                title: 'Registro del Guardián',
+                story: `# 📋 El Registro del Guardián
+
+La Cámara del Consejo brilla con luz ancestral. Ante ti yace el **Registro del Guardián** — un censo de todos los que han demostrado su valía.
+
+*"Para proteger el reino, debes controlar quién puede actuar,"* declara el Líder del Consejo. *"Aprende el arte del control de acceso."*
+
+## Tu Misión
+
+Construye un contrato de registro con control de acceso:
+- \`register\` — registra un nuevo guardián (almacena su nombre)
+- \`get_guardian\` — recupera el nombre de un guardián por su dirección
+- Una dirección \`admin\` que se establece en la inicialización
+
+## Lo Que Aprenderás
+
+- El tipo \`Address\` para identidades de usuario
+- \`require_auth()\` para control de acceso
+- Trabajar con el tipo \`Map\` para pares clave-valor
+- Patrones de inicialización de contratos
+
+## Conceptos Clave
+
+\`\`\`rust
+Address                     // Representa una cuenta/identidad
+address.require_auth()      // Garantiza que quien llama está autorizado
+Map<Address, Symbol>        // Mapeo clave-valor
+\`\`\``,
+                learningGoal: 'Implementa control de acceso con Address y require_auth',
+                hints: [
+                    'La función init almacena el admin: `env.storage().instance().set(&ADMIN, &admin)`',
+                    'En register, llama a `who.require_auth()` antes de almacenar',
+                    'Almacena con: `env.storage().instance().set(&who, &name)`',
+                ],
+            },
+        },
         template: `#![no_std]
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol, Map};
 
@@ -352,22 +526,19 @@ impl LedgerContract {
             { type: 'contains_pattern', pattern: 'require_auth()', message: 'Must use require_auth() for access control', description: 'require_auth() call' },
             { type: 'storage_operation', operation: 'set', message: 'Must use storage set' },
         ],
-        hints: [
-            'The init function stores the admin: `env.storage().instance().set(&ADMIN, &admin)`',
-            'In register, call `who.require_auth()` before storing',
-            'Store with: `env.storage().instance().set(&who, &name)`',
-        ],
         conceptsIntroduced: ['Address', 'require_auth', 'Map', 'init pattern'],
     },
 
     {
         id: 'token-forge',
-        title: 'Token Forge',
         chapter: 3,
         order: 5,
         difficulty: 'intermediate',
         xpReward: 300,
-        story: `# ⚒️ The Token Forge
+        i18n: {
+            en: {
+                title: 'Token Forge',
+                story: `# ⚒️ The Token Forge
 
 Deep within the Citadel lies the **Token Forge**, where digital assets are minted from pure logic.
 
@@ -396,7 +567,52 @@ admin.require_auth();
 // Balance management
 let bal: i128 = env.storage().persistent().get(&from).unwrap_or(0);
 \`\`\``,
-        learningGoal: 'Build a basic token with mint, balance, and transfer functions',
+                learningGoal: 'Build a basic token with mint, balance, and transfer functions',
+                hints: [
+                    'For mint: get admin from storage, call admin.require_auth(), then update balance',
+                    'For balance: `env.storage().persistent().get(&account).unwrap_or(0)`',
+                    'For transfer: require_auth from sender, read both balances, update both',
+                ],
+            },
+            es: {
+                title: 'La Forja de Tokens',
+                story: `# ⚒️ La Forja de Tokens
+
+En lo más profundo de la Ciudadela yace la **Forja de Tokens**, donde los activos digitales se acuñan a partir de pura lógica.
+
+*"La moneda es la savia de toda economía,"* dice el Maestro Forjador. *"Crearás un token que pueda transferirse entre cuentas."*
+
+## Tu Misión
+
+Crea un contrato de token simple:
+- \`mint\` — crea tokens para una dirección (solo admin)
+- \`balance\` — devuelve el saldo de una dirección
+- \`transfer\` — mueve tokens de una dirección a otra
+
+## Lo Que Aprenderás
+
+- Gestión de saldos de tokens
+- Lógica de transferencia con autorización
+- Funciones restringidas al admin
+- Aritmética de enteros para los saldos
+
+## Conceptos Clave
+
+\`\`\`rust
+// Patrón de verificación de admin
+admin.require_auth();
+
+// Gestión de saldos
+let bal: i128 = env.storage().persistent().get(&from).unwrap_or(0);
+\`\`\``,
+                learningGoal: 'Construye un token básico con funciones mint, balance y transfer',
+                hints: [
+                    'Para mint: obtén el admin del almacenamiento, llama a admin.require_auth(), luego actualiza el saldo',
+                    'Para balance: `env.storage().persistent().get(&account).unwrap_or(0)`',
+                    'Para transfer: require_auth del remitente, lee ambos saldos, actualiza ambos',
+                ],
+            },
+        },
         template: `#![no_std]
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
 
@@ -468,22 +684,19 @@ impl TokenContract {
             { type: 'storage_operation', operation: 'set', message: 'Must use storage set for balances' },
             { type: 'storage_operation', operation: 'get', message: 'Must use storage get for balances' },
         ],
-        hints: [
-            'For mint: get admin from storage, call admin.require_auth(), then update balance',
-            'For balance: `env.storage().persistent().get(&account).unwrap_or(0)`',
-            'For transfer: require_auth from sender, read both balances, update both',
-        ],
         conceptsIntroduced: ['token', 'mint', 'transfer', 'persistent storage', 'i128'],
     },
 
     {
         id: 'time-lock',
-        title: 'The Time Lock',
         chapter: 3,
         order: 6,
         difficulty: 'advanced',
         xpReward: 350,
-        story: `# ⏳ The Chrono Gate
+        i18n: {
+            en: {
+                title: 'The Time Lock',
+                story: `# ⏳ The Chrono Gate
 
 The **Chrono Gate** stands before you, its mechanisms ticking with the rhythm of the ledger.
 
@@ -509,7 +722,49 @@ Create a time-locked vault:
 env.ledger().sequence()  // Current ledger sequence number
 panic!("message")        // Abort with error
 \`\`\``,
-        learningGoal: 'Implement time-based conditional logic using ledger sequence',
+                learningGoal: 'Implement time-based conditional logic using ledger sequence',
+                hints: [
+                    'Use `env.ledger().sequence()` to get the current ledger number',
+                    'Compare: `if current_seq < unlock_at { panic!("Still locked"); }`',
+                    'Clear storage after unlock: `env.storage().instance().remove(&key)`',
+                ],
+            },
+            es: {
+                title: 'El Cerrojo Temporal',
+                story: `# ⏳ La Puerta del Tiempo
+
+La **Puerta del Tiempo** se alza ante ti, sus mecanismos marcando el ritmo del ledger.
+
+*"El tiempo es un arma,"* dice el Guardián del Tiempo. *"Aprende a bloquear y desbloquear según el paso de los bloques."*
+
+## Tu Misión
+
+Crea una bóveda con cerrojo temporal:
+- \`lock\` — bloquea tokens hasta un número de secuencia de ledger específico
+- \`unlock\` — libera los tokens si el período de bloqueo ha pasado
+- \`get_lock_info\` — devuelve cuándo expira el bloqueo
+
+## Lo Que Aprenderás
+
+- Secuencia / marca de tiempo del ledger para lógica temporal
+- Ejecución condicional basada en el estado de la blockchain
+- \`env.ledger().sequence()\` para el bloque actual
+- Patrones de panic para el manejo de errores
+
+## Conceptos Clave
+
+\`\`\`rust
+env.ledger().sequence()  // Número de secuencia del ledger actual
+panic!("message")        // Abortar con un error
+\`\`\``,
+                learningGoal: 'Implementa lógica condicional basada en el tiempo usando la secuencia del ledger',
+                hints: [
+                    'Usa `env.ledger().sequence()` para obtener el número de ledger actual',
+                    'Compara: `if current_seq < unlock_at { panic!("Still locked"); }`',
+                    'Limpia el almacenamiento tras desbloquear: `env.storage().instance().remove(&key)`',
+                ],
+            },
+        },
         template: `#![no_std]
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
 
@@ -586,22 +841,19 @@ impl TimeLockContract {
             { type: 'contains_pattern', pattern: 'panic!', message: 'Must panic if still locked', description: 'panic! for errors' },
             { type: 'storage_operation', operation: 'set', message: 'Must store lock data' },
         ],
-        hints: [
-            'Use `env.ledger().sequence()` to get the current ledger number',
-            'Compare: `if current_seq < unlock_at { panic!("Still locked"); }`',
-            'Clear storage after unlock: `env.storage().instance().remove(&key)`',
-        ],
         conceptsIntroduced: ['ledger sequence', 'time-lock', 'conditional panic', 'remove storage'],
     },
 
     {
         id: 'multi-party-pact',
-        title: 'Multi-Party Pact',
         chapter: 3,
         order: 7,
         difficulty: 'advanced',
         xpReward: 400,
-        story: `# 🤝 The Hall of Pacts
+        i18n: {
+            en: {
+                title: 'Multi-Party Pact',
+                story: `# 🤝 The Hall of Pacts
 
 You have reached the **Hall of Pacts**, the final challenge before earning your place among the Guardians.
 
@@ -632,7 +884,54 @@ let count: u32 = env.storage().instance()
 // Store with dynamic keys
 env.storage().instance().set(&signer_key, &true);
 \`\`\``,
-        learningGoal: 'Build a multi-signature pact contract with complex state management',
+                learningGoal: 'Build a multi-signature pact contract with complex state management',
+                hints: [
+                    'In create_pact: store the description, required count, and initial signed count of 0',
+                    'In sign_pact: read current count, increment by 1, store back',
+                    'In is_complete: compare signed >= required',
+                ],
+            },
+            es: {
+                title: 'Pacto Multipartito',
+                story: `# 🤝 El Salón de los Pactos
+
+Has llegado al **Salón de los Pactos**, el desafío final antes de ganar tu lugar entre los Guardianes.
+
+*"El verdadero poder de los contratos inteligentes,"* declara el Gran Anciano, *"es que permiten la confianza entre desconocidos."*
+
+## Tu Misión
+
+Crea un contrato de acuerdo con múltiples firmas:
+- \`create_pact\` — crea un acuerdo que requiere N firmas
+- \`sign_pact\` — permite que una parte firme el acuerdo
+- \`is_complete\` — comprueba si se han reunido todas las firmas requeridas
+- \`get_signers\` — devuelve quién ha firmado
+
+## Lo Que Aprenderás
+
+- Estructuras de datos complejas en contratos
+- Autorización de múltiples partes
+- Conteo y seguimiento con almacenamiento
+- Construcción de patrones de gobernanza del mundo real
+
+## Conceptos Clave
+
+\`\`\`rust
+// Llevar la cuenta de firmantes
+let count: u32 = env.storage().instance()
+    .get(&SIGNER_COUNT).unwrap_or(0);
+
+// Almacenar con claves dinámicas
+env.storage().instance().set(&signer_key, &true);
+\`\`\``,
+                learningGoal: 'Construye un contrato de pacto con múltiples firmas y gestión de estado compleja',
+                hints: [
+                    'En create_pact: almacena la descripción, el número requerido y un conteo inicial de firmas de 0',
+                    'En sign_pact: lee el conteo actual, increméntalo en 1, guárdalo de nuevo',
+                    'En is_complete: compara signed >= required',
+                ],
+            },
+        },
         template: `#![no_std]
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
 
@@ -710,11 +1009,46 @@ impl PactContract {
             { type: 'contains_pattern', pattern: 'require_auth()', message: 'Must use require_auth()', description: 'require_auth()' },
             { type: 'storage_operation', operation: 'set', message: 'Must use storage operations' },
         ],
-        hints: [
-            'In create_pact: store the description, required count, and initial signed count of 0',
-            'In sign_pact: read current count, increment by 1, store back',
-            'In is_complete: compare signed >= required',
-        ],
         conceptsIntroduced: ['multi-sig', 'bool', 'governance pattern', 'complex state'],
     },
 ];
+
+/* ==========================================
+   Localization helpers
+   ========================================== */
+
+/**
+ * Returns a flat, render-ready mission object for the given language.
+ * Localizable fields (title, story, learningGoal, hints) are resolved
+ * from `mission.i18n[lang]`, falling back to English, then to any
+ * legacy top-level field. The `i18n` block itself is omitted from the
+ * returned object so consumers keep using `mission.title` etc.
+ */
+export function localizeMission(mission, lang = DEFAULT_MISSION_LANG) {
+    if (!mission) return mission;
+
+    const { i18n, ...neutral } = mission;
+    const locale =
+        (i18n && (i18n[lang] || i18n[DEFAULT_MISSION_LANG])) || {};
+    const fallback = (i18n && i18n[DEFAULT_MISSION_LANG]) || {};
+
+    const pick = (field) =>
+        locale[field] != null
+            ? locale[field]
+            : fallback[field] != null
+            ? fallback[field]
+            : neutral[field];
+
+    return {
+        ...neutral,
+        title: pick('title'),
+        story: pick('story'),
+        learningGoal: pick('learningGoal'),
+        hints: pick('hints') || [],
+    };
+}
+
+/** Localizes an array of missions. */
+export function localizeMissions(list, lang = DEFAULT_MISSION_LANG) {
+    return (list || []).map((m) => localizeMission(m, lang));
+}

--- a/src/i18n/i18n.css
+++ b/src/i18n/i18n.css
@@ -1,0 +1,108 @@
+/* =========================
+   LANGUAGE SELECTOR
+   Append to src/index.css
+   ========================= */
+
+.language-selector {
+  position: relative;
+  display: inline-flex;
+}
+
+.language-selector-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.65rem;
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  background: transparent;
+  transition: all var(--transition-fast);
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.language-selector-trigger:hover {
+  color: var(--text-primary);
+  background: var(--bg-glass);
+}
+
+.language-selector-trigger[aria-expanded="true"] {
+  color: var(--cyan);
+  background: var(--bg-glass);
+}
+
+.language-selector-code {
+  font-family: var(--font-display);
+}
+
+.language-selector-menu {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  min-width: 160px;
+  list-style: none;
+  margin: 0;
+  padding: 0.35rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  z-index: calc(var(--z-navbar) + 1);
+  animation: language-menu-in 150ms ease;
+}
+
+@keyframes language-menu-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.language-selector-option {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.5rem 0.65rem;
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  text-align: left;
+  transition: all var(--transition-fast);
+}
+
+.language-selector-option:hover {
+  background: var(--bg-glass);
+  color: var(--text-primary);
+}
+
+.language-selector-option.active {
+  color: var(--cyan);
+  background: var(--cyan-dim, rgba(6, 214, 160, 0.1));
+}
+
+.language-selector-option-code {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.5px;
+  min-width: 26px;
+}
+
+.language-selector-option-name {
+  flex: 1;
+}
+
+/* On mobile, anchor the menu to the left of the trigger so it stays in-viewport */
+@media (max-width: 768px) {
+  .mobile-stats .language-selector-menu {
+    right: auto;
+    left: 0;
+  }
+}

--- a/src/i18n/index.jsx
+++ b/src/i18n/index.jsx
@@ -1,0 +1,134 @@
+/* ==========================================
+   i18n — Lightweight client-side internationalization
+   ========================================== */
+
+import React, {
+  createContext,
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+} from 'react';
+
+import en from './locales/en.json';
+import es from './locales/es.json';
+import { setActiveLanguage } from './languageBridge.js';
+
+const LOCALES = { en, es };
+const SUPPORTED = ['en', 'es'];
+const STORAGE_KEY = 'soroban_quest_lang';
+const DEFAULT_LANG = 'en';
+
+export const LanguageContext = createContext(null);
+
+/* ---------- helpers ---------- */
+
+function detectBrowserLanguage() {
+  if (typeof navigator === 'undefined') return DEFAULT_LANG;
+
+  const candidates = [
+    ...(navigator.languages || []),
+    navigator.language,
+  ].filter(Boolean);
+
+  for (const c of candidates) {
+    const base = String(c).toLowerCase().split('-')[0];
+    if (SUPPORTED.includes(base)) return base;
+  }
+  return DEFAULT_LANG;
+}
+
+function readStoredLanguage() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored && SUPPORTED.includes(stored)) return stored;
+  } catch {
+    /* localStorage unavailable (private mode, SSR, etc.) — ignore */
+  }
+  return null;
+}
+
+function resolveKey(dict, key) {
+  return key
+    .split('.')
+    .reduce((acc, part) => (acc == null ? undefined : acc[part]), dict);
+}
+
+function interpolate(template, vars) {
+  if (typeof template !== 'string' || !vars) return template;
+  return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (_, name) =>
+    vars[name] != null ? String(vars[name]) : `{{${name}}}`,
+  );
+}
+
+/* ---------- Provider ---------- */
+
+export function LanguageProvider({ children }) {
+  const [language, setLanguageState] = useState(() => {
+    const initial = readStoredLanguage() || detectBrowserLanguage();
+    // Sync the bridge immediately so first-render data loads localize
+    // correctly, before the effect below runs.
+    setActiveLanguage(initial);
+    return initial;
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, language);
+    } catch {
+      /* ignore */
+    }
+    if (typeof document !== 'undefined') {
+      document.documentElement.lang = language;
+    }
+    // Keep the non-React language bridge in sync so data loaders
+    // (missions/campaigns) localize against the active language.
+    setActiveLanguage(language);
+  }, [language]);
+
+  // t('a.b.c', { name: 'World' })
+  const t = useCallback(
+    (key, vars) => {
+      if (!key) return '';
+      const dict = LOCALES[language] || LOCALES[DEFAULT_LANG];
+      const fallback = LOCALES[DEFAULT_LANG];
+
+      let value = resolveKey(dict, key);
+      if (value == null) value = resolveKey(fallback, key);
+      if (value == null) {
+        if (import.meta?.env?.DEV) {
+          // Surface missing keys in development without crashing
+          // eslint-disable-next-line no-console
+          console.warn(`[i18n] Missing translation key: "${key}"`);
+        }
+        return key;
+      }
+      return interpolate(value, vars);
+    },
+    [language],
+  );
+
+  const setLanguage = useCallback((lang) => {
+    if (SUPPORTED.includes(lang)) setLanguageState(lang);
+  }, []);
+
+  const languages = useMemo(
+    () =>
+      SUPPORTED.map((code) => ({
+        code,
+        name: LOCALES[code]?.languages?.[code] || code.toUpperCase(),
+      })),
+    [],
+  );
+
+  const value = useMemo(
+    () => ({ t, language, setLanguage, languages }),
+    [t, language, setLanguage, languages],
+  );
+
+  return (
+    <LanguageContext.Provider value={value}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}

--- a/src/i18n/languageBridge.js
+++ b/src/i18n/languageBridge.js
@@ -1,0 +1,38 @@
+/* ==========================================
+   Language Bridge — exposes the active UI language to plain
+   (non-React) modules such as the mission/campaign loaders.
+
+   The LanguageProvider calls `setActiveLanguage()` whenever the
+   language changes, so data helpers can localize content without
+   needing access to React context.
+   ========================================== */
+
+export const SUPPORTED_LANGS = ['en', 'es'];
+export const DEFAULT_LANG = 'en';
+
+let activeLanguage = DEFAULT_LANG;
+const listeners = new Set();
+
+/** Read the current active language code (e.g. 'en' | 'es'). */
+export function getActiveLanguage() {
+    return activeLanguage;
+}
+
+/** Update the active language. Called by the LanguageProvider. */
+export function setActiveLanguage(lang) {
+    if (!SUPPORTED_LANGS.includes(lang) || lang === activeLanguage) return;
+    activeLanguage = lang;
+    for (const fn of listeners) {
+        try {
+            fn(activeLanguage);
+        } catch {
+            /* ignore listener errors */
+        }
+    }
+}
+
+/** Subscribe to language changes. Returns an unsubscribe function. */
+export function onLanguageChange(fn) {
+    listeners.add(fn);
+    return () => listeners.delete(fn);
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,412 @@
+{
+  "languages": {
+    "en": "English",
+    "es": "Español"
+  },
+  "common": {
+    "selectLanguage": "Select language",
+    "toggleTheme": "Toggle theme",
+    "back": "Back",
+    "close": "Close",
+    "save": "Save",
+    "cancel": "Cancel",
+    "loading": "Loading…",
+    "all": "All",
+    "level": "Level",
+    "xp": "XP",
+    "chapter": "Chapter",
+    "mission": "Mission",
+    "complete": "Complete",
+    "completed": "Completed",
+    "locked": "Locked",
+    "unlocked": "Unlocked"
+  },
+  "navbar": {
+    "home": "Home",
+    "campaigns": "Campaigns",
+    "missions": "Missions",
+    "profile": "Profile",
+    "journal": "Journal"
+  },
+  "home": {
+    "badge": "✨ Zero setup • No wallet needed • Open source",
+    "title": {
+      "lead": "Master",
+      "brand": "Soroban",
+      "tail": "Smart Contracts"
+    },
+    "subtitle": "Embark on an epic quest to learn Stellar's smart contract platform. Write real Soroban code in your browser, solve challenges, and level up your blockchain skills — no installation required.",
+    "cta": {
+      "continueQuest": "⚔️ Continue Quest",
+      "viewProgress": "📊 View Progress",
+      "beginJourney": "🚀 Begin Your Journey",
+      "viewMissionMap": "🗺️ View Mission Map"
+    },
+    "stats": {
+      "missions": "Missions",
+      "totalXp": "Total XP",
+      "backendNeeded": "Backend Needed"
+    },
+    "howItWorks": {
+      "title": "How It Works",
+      "subtitle": "Your path from zero to Soroban mastery, entirely in the browser."
+    },
+    "features": {
+      "read": {
+        "title": "Read the Quest",
+        "body": "Each mission unfolds a story while teaching core Soroban concepts. Learn about contracts, storage, tokens, and more through narrative-driven challenges."
+      },
+      "write": {
+        "title": "Write the Code",
+        "body": "Use the built-in Monaco editor with Rust syntax highlighting and Soroban autocomplete. Templates get you started — you fill in the logic."
+      },
+      "test": {
+        "title": "Run the Tests",
+        "body": "Validate your code with instant feedback. Each mission has hidden checks that verify your contract structure, functions, and patterns."
+      },
+      "xp": {
+        "title": "Earn XP & Level Up",
+        "body": "Gain experience points for each completed mission. Unlock badges, climb ranks, and track your journey from Initiate to Stellar Sovereign."
+      },
+      "zeroBackend": {
+        "title": "Zero Backend",
+        "body": "Everything runs in your browser. No servers, no databases, no accounts. Your progress is saved locally — export it anytime as a JSON file."
+      },
+      "path": {
+        "title": "Progressive Path",
+        "body": "From \"Hello World\" to multi-signature contracts. Each mission builds on the last, creating a structured path to Soroban mastery."
+      }
+    }
+  },
+  "footer": {
+    "platform": {
+      "heading": "Platform",
+      "home": "Home",
+      "missions": "Missions",
+      "profile": "Profile",
+      "glossary": "Glossary"
+    },
+    "resources": {
+      "heading": "Resources",
+      "docs": "Soroban Docs",
+      "sdk": "Stellar SDK",
+      "github": "GitHub"
+    },
+    "community": {
+      "heading": "Community",
+      "discord": "Discord",
+      "telegram": "Telegram"
+    },
+    "credits": {
+      "tagline": "Built for the Stellar ecosystem",
+      "license": "MIT License"
+    }
+  },
+  "notFound": {
+    "title": "This quest does not exist",
+    "body": "You seem to have wandered into deep space",
+    "back": "Return to Base"
+  },
+  "errorBoundary": {
+    "generic": {
+      "title": "Something went wrong",
+      "body": "The quest encountered a runtime error. Check the console for details.",
+      "reload": "Reload",
+      "report": "Report Issue"
+    },
+    "editor": {
+      "body": "Editor failed to load",
+      "reset": "Reset Editor"
+    },
+    "mission": {
+      "title": "Mission unavailable",
+      "retry": "Try again"
+    }
+  },
+  "profile": {
+    "edit": "✏️ Edit Profile",
+    "viewJournal": "📖 View Journal",
+    "editPanel": {
+      "title": "Edit Profile",
+      "namePlaceholder": "Enter name"
+    },
+    "stats": {
+      "missions": "Missions",
+      "badges": "Badges"
+    },
+    "sections": {
+      "badges": "🏅 Badges",
+      "completedMissions": "✅ Completed Missions",
+      "data": "⚙️ Data"
+    },
+    "noMissions": "No missions completed yet.",
+    "xpBar": {
+      "current": "{{current}} / {{needed}} XP",
+      "total": "Total: {{xp}} XP"
+    },
+    "data": {
+      "export": "Export",
+      "import": "Import",
+      "reset": "Reset",
+      "confirmReset": "Reset all progress? This cannot be undone.",
+      "status": {
+        "exported": "✅ Progress exported!",
+        "imported": "✅ Progress imported successfully!",
+        "importFailed": "❌ Invalid file — could not import.",
+        "resetDone": "🗑️ Progress reset."
+      },
+      "log": {
+        "exported": "Exported adventure progress",
+        "imported": "Imported adventure progress from file"
+      }
+    }
+  },
+  "journal": {
+    "title": "Adventure Journal",
+    "subtitle": "Your journey through the Soroban realm, recorded for eternity.",
+    "clearLog": "🗑️ Clear Log",
+    "confirmClear": "Clear all activity history?",
+    "summary": {
+      "missions": "Missions",
+      "badges": "Badges",
+      "level": "Level",
+      "totalXp": "Total XP",
+      "streak": "Day Streak"
+    },
+    "filters": {
+      "all": "All",
+      "mission": "Mission",
+      "badge": "Badge",
+      "levelUp": "Level Up",
+      "hint": "Hint",
+      "system": "System"
+    },
+    "empty": "No activities recorded yet. Start your first mission!",
+    "dates": {
+      "today": "Today",
+      "yesterday": "Yesterday"
+    },
+    "events": {
+      "missionStarted": "Started mission: {{title}}",
+      "missionCompleted": "Completed mission: {{title}}",
+      "badgeEarned": "Earned the \"{{name}}\" badge!",
+      "levelUp": "Reached Level {{level}}!",
+      "hintUsed": "Used hint {{index}}",
+      "export": "Exported adventure progress",
+      "import": "Imported adventure progress from file",
+      "streakOne": "Daily streak: 1 day!",
+      "streakMany": "Daily streak: {{count}} days!"
+    },
+    "details": {
+      "targetXp": "Target XP reached: {{xp}}",
+      "earnedXp": "Earned {{xp}} XP"
+    },
+    "eventLabels": {
+      "mission": "Mission",
+      "badge": "Badge",
+      "levelUp": "Level Up",
+      "hint": "Hint",
+      "system": "System",
+      "streak": "Streak"
+    }
+  },
+  "campaigns": {
+    "title": "Campaigns",
+    "subtitle": "Epic story-driven chapters | Level {{level}} | {{completed}}/{{total}} total missions",
+    "chapter": "Chapter {{number}}",
+    "missionCount": "{{completed}}/{{total}} missions",
+    "lockedAt": "🔒 Reach Level {{level}} to unlock",
+    "chapterComplete": "✓ Chapter Complete!",
+    "back": "← Back to Campaigns",
+    "completeOf": "{{completed}}/{{total}} Complete",
+    "lore": {
+      "modalTitle": "Chapter Introduction",
+      "beginChapter": "Begin Chapter {{number}}"
+    }
+  },
+  "missionMap": {
+    "title": "Mission Map",
+    "subtitle": "{{completed}} of {{total}} missions completed",
+    "searchPlaceholder": "Search missions…",
+    "difficulty": {
+      "all": "All",
+      "beginner": "Beginner",
+      "intermediate": "Intermediate",
+      "advanced": "Advanced"
+    },
+    "chapters": {
+      "all": "All Chapters",
+      "n": "Chapter {{number}}"
+    },
+    "card": {
+      "chapterMission": "Chapter {{chapter}} • Mission {{mission}}",
+      "xp": "⚡ {{xp}} XP",
+      "completed": "✓ Completed",
+      "locked": "🔒 Locked"
+    },
+    "noResults": "No missions found matching your filters.",
+    "aria": {
+      "missionPath": "Mission path graph",
+      "missionTimeline": "Mission timeline",
+      "missionItem": "Mission {{order}}: {{title}}",
+      "missionItemCompleted": "Mission {{order}}: {{title}}, completed",
+      "missionItemUnlocked": "Mission {{order}}: {{title}}, unlocked",
+      "missionItemLocked": "Mission {{order}}: {{title}}, locked"
+    }
+  },
+  "missionDetail": {
+    "tabs": {
+      "story": "Story",
+      "editor": "Editor",
+      "tests": "Tests",
+      "replay": "📹 Replay"
+    },
+    "notFound": {
+      "title": "Mission Not Found",
+      "body": "The mission \"{{id}}\" doesn't exist.",
+      "back": "← Back to Mission Map"
+    },
+    "editor": {
+      "reset": "↺ Reset",
+      "hint": "💡 Hint",
+      "solution": "👁️ Solution",
+      "run": "▶ Run Tests",
+      "running": "Running…"
+    },
+    "terminal": {
+      "title": "Test Output",
+      "placeholder": "Click \"Run Tests\" to validate your code…",
+      "runningChecks": "🔍 Running validation checks…",
+      "alreadyCompleted": "🏅 Already completed — no additional XP awarded."
+    },
+    "status": {
+      "checking": "Checking…",
+      "passing": "{{passed}}/{{total}} checks passing",
+      "allPassing": "{{passed}}/{{total}} checks passing ✓",
+      "note": "live checks · full suite on Run Tests"
+    },
+    "toasts": {
+      "validated": "Mission Parameters Validated!",
+      "validationFailed": "Validation failed. Check terminal.",
+      "hintUnlocked": "Hint {{index}} unlocked",
+      "codeReset": "Code reset to template",
+      "solutionLoaded": "Solution loaded into editor"
+    },
+    "hint": {
+      "label": "💡 Hint {{index}}:"
+    },
+    "victory": {
+      "title": "Mission Complete!",
+      "youCompleted": "You've completed",
+      "xpGained": "+{{xp}} XP",
+      "levelUp": "🎉 Level Up! You are now Level {{level}} — {{rank}}",
+      "badgeEarnedOne": "🏅 New badge earned!",
+      "badgeEarnedMany": "🏅 New badges earned!",
+      "next": "Next Mission →",
+      "map": "Mission Map"
+    },
+    "replay": {
+      "header": "📹 Watch Your Solution",
+      "body": "Review your problem-solving process step by step.",
+      "start": "▶️ Start Replay"
+    },
+    "okashi": {
+      "button": "🚀 Try on Okashi — Compile & Deploy",
+      "help": "Opens okashi.dev in a new tab. Your code is copied to clipboard — paste it there to compile with the real Soroban compiler and deploy to Testnet."
+    }
+  },
+  "skillTree": {
+    "title": "Soroban Skill Tree",
+    "subtitle": "Track your mastery of Soroban smart contract concepts",
+    "overall": "{{unlocked}}/{{total}} Concepts Mastered",
+    "categoryProgress": "{{unlocked}}/{{total}}",
+    "categories": {
+      "Core": {
+        "title": "Core Concepts",
+        "description": "Fundamental Soroban building blocks"
+      },
+      "Storage": {
+        "title": "Storage & State",
+        "description": "Managing persistent data"
+      },
+      "Types": {
+        "title": "Data Types",
+        "description": "Working with different data types"
+      },
+      "Auth": {
+        "title": "Authorization",
+        "description": "Access control and security"
+      },
+      "Advanced": {
+        "title": "Advanced Patterns",
+        "description": "Complex contract patterns"
+      }
+    },
+    "tooltip": {
+      "chapter": "Chapter {{chapter}}"
+    },
+    "modal": {
+      "taughtIn": "Taught in: {{title}}",
+      "chapterLabel": "Chapter:",
+      "difficultyLabel": "Difficulty:",
+      "xpLabel": "XP Reward:",
+      "learningGoal": "Learning Goal:",
+      "completed": "✅ Completed",
+      "notCompleted": "🔒 Not yet completed",
+      "startMission": "Start Mission",
+      "notCovered": "This concept is not yet covered in available missions."
+    }
+  },
+  "ranks": {
+    "0": "Initiate",
+    "1": "Apprentice",
+    "2": "Scribe",
+    "3": "Coder",
+    "4": "Architect",
+    "5": "Sentinel",
+    "6": "Guardian",
+    "7": "Master Guardian",
+    "8": "Elder",
+    "9": "Luminary",
+    "10": "Stellar Sovereign"
+  },
+  "difficulty": {
+    "beginner": "beginner",
+    "intermediate": "intermediate",
+    "advanced": "advanced"
+  },
+  "badges": {
+    "first_contract": {
+      "name": "First Contract",
+      "description": "Complete your first mission"
+    },
+    "triple_threat": {
+      "name": "Triple Threat",
+      "description": "Complete 3 missions"
+    },
+    "five_star": {
+      "name": "Five Star",
+      "description": "Complete 5 missions"
+    },
+    "completionist": {
+      "name": "Completionist",
+      "description": "Complete all missions"
+    },
+    "level_3": {
+      "name": "Rising Star",
+      "description": "Reach level 3"
+    },
+    "level_5": {
+      "name": "Stellar Guardian",
+      "description": "Reach level 5"
+    },
+    "xp_1000": {
+      "name": "XP Hoarder",
+      "description": "Earn 1000 XP"
+    },
+    "speed_demon": {
+      "name": "Speed Demon",
+      "description": "Complete a mission on first try"
+    }
+  }
+}

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1,0 +1,412 @@
+{
+  "languages": {
+    "en": "English",
+    "es": "Español"
+  },
+  "common": {
+    "selectLanguage": "Seleccionar idioma",
+    "toggleTheme": "Cambiar tema",
+    "back": "Volver",
+    "close": "Cerrar",
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "loading": "Cargando…",
+    "all": "Todas",
+    "level": "Nivel",
+    "xp": "XP",
+    "chapter": "Capítulo",
+    "mission": "Misión",
+    "complete": "Completa",
+    "completed": "Completada",
+    "locked": "Bloqueada",
+    "unlocked": "Desbloqueada"
+  },
+  "navbar": {
+    "home": "Inicio",
+    "campaigns": "Campañas",
+    "missions": "Misiones",
+    "profile": "Perfil",
+    "journal": "Diario"
+  },
+  "home": {
+    "badge": "✨ Sin configuración • Sin billetera • Código abierto",
+    "title": {
+      "lead": "Domina",
+      "brand": "Soroban",
+      "tail": "Contratos Inteligentes"
+    },
+    "subtitle": "Embárcate en una épica aventura para aprender la plataforma de contratos inteligentes de Stellar. Escribe código real de Soroban en tu navegador, resuelve desafíos y mejora tus habilidades en blockchain — sin instalación.",
+    "cta": {
+      "continueQuest": "⚔️ Continuar misión",
+      "viewProgress": "📊 Ver progreso",
+      "beginJourney": "🚀 Comienza tu aventura",
+      "viewMissionMap": "🗺️ Ver mapa de misiones"
+    },
+    "stats": {
+      "missions": "Misiones",
+      "totalXp": "XP total",
+      "backendNeeded": "Backend necesario"
+    },
+    "howItWorks": {
+      "title": "Cómo funciona",
+      "subtitle": "Tu camino desde cero hasta dominar Soroban, todo desde el navegador."
+    },
+    "features": {
+      "read": {
+        "title": "Lee la misión",
+        "body": "Cada misión despliega una historia mientras enseña los conceptos esenciales de Soroban. Aprende sobre contratos, almacenamiento, tokens y más a través de desafíos narrativos."
+      },
+      "write": {
+        "title": "Escribe el código",
+        "body": "Usa el editor Monaco integrado con resaltado de sintaxis de Rust y autocompletado de Soroban. Las plantillas te dan un punto de partida — tú completas la lógica."
+      },
+      "test": {
+        "title": "Ejecuta las pruebas",
+        "body": "Valida tu código con retroalimentación instantánea. Cada misión tiene verificaciones ocultas que comprueban la estructura, las funciones y los patrones de tu contrato."
+      },
+      "xp": {
+        "title": "Gana XP y sube de nivel",
+        "body": "Obtén puntos de experiencia por cada misión completada. Desbloquea insignias, escala rangos y sigue tu viaje desde Iniciado hasta Soberano Estelar."
+      },
+      "zeroBackend": {
+        "title": "Cero backend",
+        "body": "Todo se ejecuta en tu navegador. Sin servidores, sin bases de datos, sin cuentas. Tu progreso se guarda localmente — expórtalo cuando quieras como un archivo JSON."
+      },
+      "path": {
+        "title": "Camino progresivo",
+        "body": "Desde \"Hello World\" hasta contratos multi-firma. Cada misión se apoya en la anterior, creando una ruta estructurada hacia el dominio de Soroban."
+      }
+    }
+  },
+  "footer": {
+    "platform": {
+      "heading": "Plataforma",
+      "home": "Inicio",
+      "missions": "Misiones",
+      "profile": "Perfil",
+      "glossary": "Glosario"
+    },
+    "resources": {
+      "heading": "Recursos",
+      "docs": "Documentación de Soroban",
+      "sdk": "SDK de Stellar",
+      "github": "GitHub"
+    },
+    "community": {
+      "heading": "Comunidad",
+      "discord": "Discord",
+      "telegram": "Telegram"
+    },
+    "credits": {
+      "tagline": "Construido para el ecosistema Stellar",
+      "license": "Licencia MIT"
+    }
+  },
+  "notFound": {
+    "title": "Esta misión no existe",
+    "body": "Parece que te has perdido en el espacio profundo",
+    "back": "Volver a la base"
+  },
+  "errorBoundary": {
+    "generic": {
+      "title": "Algo salió mal",
+      "body": "La misión encontró un error en tiempo de ejecución. Revisa la consola para más detalles.",
+      "reload": "Recargar",
+      "report": "Reportar problema"
+    },
+    "editor": {
+      "body": "El editor no se pudo cargar",
+      "reset": "Reiniciar editor"
+    },
+    "mission": {
+      "title": "Misión no disponible",
+      "retry": "Reintentar"
+    }
+  },
+  "profile": {
+    "edit": "✏️ Editar perfil",
+    "viewJournal": "📖 Ver diario",
+    "editPanel": {
+      "title": "Editar perfil",
+      "namePlaceholder": "Ingresa tu nombre"
+    },
+    "stats": {
+      "missions": "Misiones",
+      "badges": "Insignias"
+    },
+    "sections": {
+      "badges": "🏅 Insignias",
+      "completedMissions": "✅ Misiones completadas",
+      "data": "⚙️ Datos"
+    },
+    "noMissions": "Aún no has completado ninguna misión.",
+    "xpBar": {
+      "current": "{{current}} / {{needed}} XP",
+      "total": "Total: {{xp}} XP"
+    },
+    "data": {
+      "export": "Exportar",
+      "import": "Importar",
+      "reset": "Restablecer",
+      "confirmReset": "¿Restablecer todo el progreso? Esto no se puede deshacer.",
+      "status": {
+        "exported": "✅ ¡Progreso exportado!",
+        "imported": "✅ ¡Progreso importado correctamente!",
+        "importFailed": "❌ Archivo inválido — no se pudo importar.",
+        "resetDone": "🗑️ Progreso restablecido."
+      },
+      "log": {
+        "exported": "Progreso de la aventura exportado",
+        "imported": "Progreso de la aventura importado desde archivo"
+      }
+    }
+  },
+  "journal": {
+    "title": "Diario de aventura",
+    "subtitle": "Tu viaje a través del reino de Soroban, registrado para la eternidad.",
+    "clearLog": "🗑️ Borrar registro",
+    "confirmClear": "¿Borrar todo el historial de actividad?",
+    "summary": {
+      "missions": "Misiones",
+      "badges": "Insignias",
+      "level": "Nivel",
+      "totalXp": "XP total",
+      "streak": "Días de racha"
+    },
+    "filters": {
+      "all": "Todo",
+      "mission": "Misión",
+      "badge": "Insignia",
+      "levelUp": "Subida de nivel",
+      "hint": "Pista",
+      "system": "Sistema"
+    },
+    "empty": "Aún no hay actividades registradas. ¡Comienza tu primera misión!",
+    "dates": {
+      "today": "Hoy",
+      "yesterday": "Ayer"
+    },
+    "events": {
+      "missionStarted": "Misión iniciada: {{title}}",
+      "missionCompleted": "Misión completada: {{title}}",
+      "badgeEarned": "¡Ganaste la insignia \"{{name}}\"!",
+      "levelUp": "¡Alcanzaste el Nivel {{level}}!",
+      "hintUsed": "Usaste la pista {{index}}",
+      "export": "Progreso de la aventura exportado",
+      "import": "Progreso de la aventura importado desde archivo",
+      "streakOne": "Racha diaria: ¡1 día!",
+      "streakMany": "Racha diaria: ¡{{count}} días!"
+    },
+    "details": {
+      "targetXp": "XP objetivo alcanzado: {{xp}}",
+      "earnedXp": "Ganaste {{xp}} XP"
+    },
+    "eventLabels": {
+      "mission": "Misión",
+      "badge": "Insignia",
+      "levelUp": "Subida de nivel",
+      "hint": "Pista",
+      "system": "Sistema",
+      "streak": "Racha"
+    }
+  },
+  "campaigns": {
+    "title": "Campañas",
+    "subtitle": "Capítulos épicos con historia | Nivel {{level}} | {{completed}}/{{total}} misiones totales",
+    "chapter": "Capítulo {{number}}",
+    "missionCount": "{{completed}}/{{total}} misiones",
+    "lockedAt": "🔒 Alcanza el nivel {{level}} para desbloquear",
+    "chapterComplete": "✓ ¡Capítulo completado!",
+    "back": "← Volver a campañas",
+    "completeOf": "{{completed}}/{{total}} completadas",
+    "lore": {
+      "modalTitle": "Introducción del capítulo",
+      "beginChapter": "Comenzar capítulo {{number}}"
+    }
+  },
+  "missionMap": {
+    "title": "Mapa de misiones",
+    "subtitle": "{{completed}} de {{total}} misiones completadas",
+    "searchPlaceholder": "Buscar misiones…",
+    "difficulty": {
+      "all": "Todas",
+      "beginner": "Principiante",
+      "intermediate": "Intermedia",
+      "advanced": "Avanzada"
+    },
+    "chapters": {
+      "all": "Todos los capítulos",
+      "n": "Capítulo {{number}}"
+    },
+    "card": {
+      "chapterMission": "Capítulo {{chapter}} • Misión {{mission}}",
+      "xp": "⚡ {{xp}} XP",
+      "completed": "✓ Completada",
+      "locked": "🔒 Bloqueada"
+    },
+    "noResults": "No hay misiones que coincidan con tus filtros.",
+    "aria": {
+      "missionPath": "Gráfico del camino de misiones",
+      "missionTimeline": "Línea de tiempo de misiones",
+      "missionItem": "Misión {{order}}: {{title}}",
+      "missionItemCompleted": "Misión {{order}}: {{title}}, completada",
+      "missionItemUnlocked": "Misión {{order}}: {{title}}, desbloqueada",
+      "missionItemLocked": "Misión {{order}}: {{title}}, bloqueada"
+    }
+  },
+  "missionDetail": {
+    "tabs": {
+      "story": "Historia",
+      "editor": "Editor",
+      "tests": "Pruebas",
+      "replay": "📹 Repetición"
+    },
+    "notFound": {
+      "title": "Misión no encontrada",
+      "body": "La misión \"{{id}}\" no existe.",
+      "back": "← Volver al mapa de misiones"
+    },
+    "editor": {
+      "reset": "↺ Reiniciar",
+      "hint": "💡 Pista",
+      "solution": "👁️ Solución",
+      "run": "▶ Ejecutar pruebas",
+      "running": "Ejecutando…"
+    },
+    "terminal": {
+      "title": "Salida de pruebas",
+      "placeholder": "Haz clic en \"Ejecutar pruebas\" para validar tu código…",
+      "runningChecks": "🔍 Ejecutando verificaciones…",
+      "alreadyCompleted": "🏅 Ya completada — no se otorgó XP adicional."
+    },
+    "status": {
+      "checking": "Verificando…",
+      "passing": "{{passed}}/{{total}} verificaciones pasando",
+      "allPassing": "{{passed}}/{{total}} verificaciones pasando ✓",
+      "note": "verificaciones en vivo · suite completa al ejecutar pruebas"
+    },
+    "toasts": {
+      "validated": "¡Parámetros de la misión validados!",
+      "validationFailed": "Validación fallida. Revisa la terminal.",
+      "hintUnlocked": "Pista {{index}} desbloqueada",
+      "codeReset": "Código restablecido a la plantilla",
+      "solutionLoaded": "Solución cargada en el editor"
+    },
+    "hint": {
+      "label": "💡 Pista {{index}}:"
+    },
+    "victory": {
+      "title": "¡Misión completada!",
+      "youCompleted": "Has completado",
+      "xpGained": "+{{xp}} XP",
+      "levelUp": "🎉 ¡Subiste de nivel! Ahora eres Nivel {{level}} — {{rank}}",
+      "badgeEarnedOne": "🏅 ¡Nueva insignia obtenida!",
+      "badgeEarnedMany": "🏅 ¡Nuevas insignias obtenidas!",
+      "next": "Siguiente misión →",
+      "map": "Mapa de misiones"
+    },
+    "replay": {
+      "header": "📹 Mira tu solución",
+      "body": "Revisa paso a paso tu proceso de resolución.",
+      "start": "▶️ Iniciar repetición"
+    },
+    "okashi": {
+      "button": "🚀 Probar en Okashi — Compilar e implementar",
+      "help": "Abre okashi.dev en una pestaña nueva. Tu código se copia al portapapeles — pégalo allí para compilarlo con el compilador real de Soroban e implementarlo en Testnet."
+    }
+  },
+  "skillTree": {
+    "title": "Árbol de habilidades de Soroban",
+    "subtitle": "Sigue tu dominio de los conceptos de contratos inteligentes de Soroban",
+    "overall": "{{unlocked}}/{{total}} conceptos dominados",
+    "categoryProgress": "{{unlocked}}/{{total}}",
+    "categories": {
+      "Core": {
+        "title": "Conceptos básicos",
+        "description": "Componentes fundamentales de Soroban"
+      },
+      "Storage": {
+        "title": "Almacenamiento y estado",
+        "description": "Gestión de datos persistentes"
+      },
+      "Types": {
+        "title": "Tipos de datos",
+        "description": "Trabajando con diferentes tipos de datos"
+      },
+      "Auth": {
+        "title": "Autorización",
+        "description": "Control de acceso y seguridad"
+      },
+      "Advanced": {
+        "title": "Patrones avanzados",
+        "description": "Patrones de contratos complejos"
+      }
+    },
+    "tooltip": {
+      "chapter": "Capítulo {{chapter}}"
+    },
+    "modal": {
+      "taughtIn": "Enseñado en: {{title}}",
+      "chapterLabel": "Capítulo:",
+      "difficultyLabel": "Dificultad:",
+      "xpLabel": "Recompensa XP:",
+      "learningGoal": "Objetivo de aprendizaje:",
+      "completed": "✅ Completada",
+      "notCompleted": "🔒 Aún no completada",
+      "startMission": "Iniciar misión",
+      "notCovered": "Este concepto aún no está cubierto en las misiones disponibles."
+    }
+  },
+  "ranks": {
+    "0": "Iniciado",
+    "1": "Aprendiz",
+    "2": "Escriba",
+    "3": "Programador",
+    "4": "Arquitecto",
+    "5": "Centinela",
+    "6": "Guardián",
+    "7": "Maestro Guardián",
+    "8": "Anciano",
+    "9": "Luminaria",
+    "10": "Soberano Estelar"
+  },
+  "difficulty": {
+    "beginner": "principiante",
+    "intermediate": "intermedia",
+    "advanced": "avanzada"
+  },
+  "badges": {
+    "first_contract": {
+      "name": "Primer Contrato",
+      "description": "Completa tu primera misión"
+    },
+    "triple_threat": {
+      "name": "Triple Amenaza",
+      "description": "Completa 3 misiones"
+    },
+    "five_star": {
+      "name": "Cinco Estrellas",
+      "description": "Completa 5 misiones"
+    },
+    "completionist": {
+      "name": "Completista",
+      "description": "Completa todas las misiones"
+    },
+    "level_3": {
+      "name": "Estrella Naciente",
+      "description": "Alcanza el nivel 3"
+    },
+    "level_5": {
+      "name": "Guardián Estelar",
+      "description": "Alcanza el nivel 5"
+    },
+    "xp_1000": {
+      "name": "Acumulador de XP",
+      "description": "Gana 1000 XP"
+    },
+    "speed_demon": {
+      "name": "Demonio Veloz",
+      "description": "Completa una misión en el primer intento"
+    }
+  }
+}

--- a/src/i18n/useTranslation.js
+++ b/src/i18n/useTranslation.js
@@ -1,0 +1,22 @@
+/* ==========================================
+   useTranslation — Hook for accessing i18n
+   ========================================== */
+
+import { useContext } from 'react';
+import { LanguageContext } from './index.jsx';
+
+export function useTranslation() {
+  const ctx = useContext(LanguageContext);
+
+  // Graceful fallback so consumers don't crash if a tree is rendered
+  // outside the provider (e.g., isolated tests or storybook).
+  if (!ctx) {
+    return {
+      t: (key) => key,
+      language: 'en',
+      setLanguage: () => {},
+      languages: [{ code: 'en', name: 'English' }],
+    };
+  }
+  return ctx;
+}

--- a/src/pages/Campaigns.jsx
+++ b/src/pages/Campaigns.jsx
@@ -1,18 +1,33 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import { Link } from "react-router-dom";
-import { missions } from "../data/missions.js";
-import { campaigns, getCampaignProgress } from "../data/campaigns.js";
+import { missions, localizeMissions } from "../data/missions.js";
+import { campaigns, localizeCampaigns, getCampaignProgress } from "../data/campaigns.js";
 import { loadProgress } from "../systems/storage.js";
 import { isMissionUnlocked } from "../systems/missionLoader.js";
+import { useTranslation } from "../i18n/useTranslation";
 
 import "./Campaigns.css";
 
 export default function Campaigns() {
+  const { t, language } = useTranslation();
   const [progress, setProgress] = useState(loadProgress());
-  const [selectedCampaign, setSelectedCampaign] = useState(null);
+  const [selectedCampaignId, setSelectedCampaignId] = useState(null);
   const [showLoreModal, setShowLoreModal] = useState(false);
   const [firstVisit, setFirstVisit] = useState(false);
+
+  const localizedCampaigns = useMemo(
+    () => localizeCampaigns(campaigns, language),
+    [language],
+  );
+  const localizedMissions = useMemo(
+    () => localizeMissions(missions, language),
+    [language],
+  );
+  const selectedCampaign = useMemo(
+    () => localizedCampaigns.find((c) => c.id === selectedCampaignId) || null,
+    [localizedCampaigns, selectedCampaignId],
+  );
 
   useEffect(() => {
     // Listen for storage changes (profile updates)
@@ -29,7 +44,7 @@ export default function Campaigns() {
       setFirstVisit(true);
       setShowLoreModal(true);
     }
-    setSelectedCampaign(campaign);
+    setSelectedCampaignId(campaign.id);
   };
 
   const closeModal = () => {
@@ -47,15 +62,18 @@ export default function Campaigns() {
   return (
     <div className="campaigns-page">
       <div className="page-header">
-        <h1 className="section-title">Campaigns</h1>
+        <h1 className="section-title">{t("campaigns.title")}</h1>
         <p className="section-subtitle">
-          Epic story-driven chapters | Level {currentLevel} |{" "}
-          {progress.completedMissions.length}/{missions.length} total missions
+          {t("campaigns.subtitle", {
+            level: currentLevel,
+            completed: progress.completedMissions.length,
+            total: missions.length,
+          })}
         </p>
       </div>
 
       <div className="campaigns-grid">
-        {campaigns.map((campaign) => {
+        {localizedCampaigns.map((campaign) => {
           const stats = getCampaignProgress(
             campaign.id,
             progress.completedMissions,
@@ -77,7 +95,7 @@ export default function Campaigns() {
                 }}
               >
                 <div className="campaign-badge">
-                  Chapter {campaign.chapterNumber}
+                  {t("campaigns.chapter", { number: campaign.chapterNumber })}
                 </div>
               </div>
 
@@ -87,7 +105,10 @@ export default function Campaigns() {
 
                 <div className="campaign-progress">
                   <div className="progress-label">
-                    {stats.completed}/{stats.total} missions
+                    {t("campaigns.missionCount", {
+                      completed: stats.completed,
+                      total: stats.total,
+                    })}
                   </div>
                   <div className="xp-bar-container">
                     <div className="xp-bar-track">
@@ -101,13 +122,13 @@ export default function Campaigns() {
 
                 {!unlocked && (
                   <div className="campaign-lock">
-                    🔒 Reach Level {campaign.requiredLevel} to unlock
+                    {t("campaigns.lockedAt", { level: campaign.requiredLevel })}
                   </div>
                 )}
 
                 {completed && (
                   <div className="campaign-status completed">
-                    ✓ Chapter Complete!
+                    {t("campaigns.chapterComplete")}
                   </div>
                 )}
               </div>
@@ -121,29 +142,29 @@ export default function Campaigns() {
           <div className="campaign-detail">
             <button
               className="detail-back"
-              onClick={() => setSelectedCampaign(null)}
+              onClick={() => setSelectedCampaignId(null)}
             >
-              ← Back to Campaigns
+              {t("campaigns.back")}
             </button>
 
             <div className="detail-header">
               <h2>{selectedCampaign.title}</h2>
               <div className="detail-stats">
                 <span>
-                  {
-                    getCampaignProgress(
+                  {t("campaigns.completeOf", {
+                    completed: getCampaignProgress(
                       selectedCampaign.id,
                       progress.completedMissions,
-                    ).completed
-                  }
-                  /{selectedCampaign.missionIds.length} Complete
+                    ).completed,
+                    total: selectedCampaign.missionIds.length,
+                  })}
                 </span>
               </div>
             </div>
 
             <div className="missions-list">
               {selectedCampaign.missionIds.map((missionId) => {
-                const mission = missions.find((m) => m.id === missionId);
+                const mission = localizedMissions.find((m) => m.id === missionId);
                 if (!mission) return null;
 
                 const missionCompleted =
@@ -162,7 +183,7 @@ export default function Campaigns() {
                     <div className="mission-order">#{mission.order}</div>
                     <div className="mission-title">{mission.title}</div>
                     <div className={`mission-badge badge-${mission.difficulty}`}>
-                      {mission.difficulty}
+                      {t(`difficulty.${mission.difficulty}`)}
                     </div>
                     {missionCompleted ? (
                       <span className="mission-status">✓</span>
@@ -181,12 +202,14 @@ export default function Campaigns() {
         <div className="modal-overlay" onClick={closeModal}>
           <div className="modal-content" onClick={(e) => e.stopPropagation()}>
             <div className="modal-icon">📜</div>
-            <h2 className="modal-title">Chapter Introduction</h2>
+            <h2 className="modal-title">{t("campaigns.lore.modalTitle")}</h2>
             <div className="modal-lore">
               <ReactMarkdown>{selectedCampaign.lore}</ReactMarkdown>
             </div>
             <button className="btn btn-primary" onClick={closeModal}>
-              Begin Chapter {selectedCampaign.chapterNumber}
+              {t("campaigns.lore.beginChapter", {
+                number: selectedCampaign.chapterNumber,
+              })}
             </button>
           </div>
         </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,13 +1,15 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import React, { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { loadProgress } from '../systems/storage';
-import { getAllMissions, isMissionUnlocked } from '../systems/missionLoader';
+import { getAllMissions } from '../systems/missionLoader';
+import { useTranslation } from '../i18n/useTranslation';
 
 export default function Home() {
     const navigate = useNavigate();
     const state = loadProgress();
     const canvasRef = useRef(null);
-    const missions = getAllMissions();
+    const { t, language } = useTranslation();
+    const missions = getAllMissions(language);
     const completedCount = state.completedMissions.length;
     const hasMissions = completedCount > 0;
 
@@ -64,37 +66,37 @@ export default function Home() {
                 <canvas ref={canvasRef} className="hero-particles" />
 
                 <div className="hero-badge">
-                    ✨ Zero setup • No wallet needed • Open source
+                    {t('home.badge')}
                 </div>
 
                 <h1 className="hero-title">
-                    Master <span className="hero-title-gradient">Soroban</span>
-                    <br />Smart Contracts
+                    {t('home.title.lead')}{' '}
+                    <span className="hero-title-gradient">{t('home.title.brand')}</span>
+                    <br />
+                    {t('home.title.tail')}
                 </h1>
 
                 <p className="hero-subtitle">
-                    Embark on an epic quest to learn Stellar's smart contract platform.
-                    Write real Soroban code in your browser, solve challenges, and level up
-                    your blockchain skills — no installation required.
+                    {t('home.subtitle')}
                 </p>
 
                 <div className="hero-actions">
                     {hasMissions ? (
                         <>
                             <button className="btn btn-primary btn-lg" onClick={() => navigate('/missions')}>
-                                ⚔️ Continue Quest
+                                {t('home.cta.continueQuest')}
                             </button>
                             <button className="btn btn-secondary btn-lg" onClick={() => navigate('/profile')}>
-                                📊 View Progress
+                                {t('home.cta.viewProgress')}
                             </button>
                         </>
                     ) : (
                         <>
                             <button className="btn btn-primary btn-lg" onClick={() => navigate('/mission/hello-soroban')}>
-                                🚀 Begin Your Journey
+                                {t('home.cta.beginJourney')}
                             </button>
                             <button className="btn btn-secondary btn-lg" onClick={() => navigate('/missions')}>
-                                🗺️ View Mission Map
+                                {t('home.cta.viewMissionMap')}
                             </button>
                         </>
                     )}
@@ -103,78 +105,60 @@ export default function Home() {
                 <div className="hero-stats">
                     <div className="hero-stat">
                         <div className="hero-stat-value">{missions.length}</div>
-                        <div className="hero-stat-label">Missions</div>
+                        <div className="hero-stat-label">{t('home.stats.missions')}</div>
                     </div>
                     <div className="hero-stat">
                         <div className="hero-stat-value">{missions.reduce((s, m) => s + m.xpReward, 0)}</div>
-                        <div className="hero-stat-label">Total XP</div>
+                        <div className="hero-stat-label">{t('home.stats.totalXp')}</div>
                     </div>
                     <div className="hero-stat">
                         <div className="hero-stat-value">0</div>
-                        <div className="hero-stat-label">Backend Needed</div>
+                        <div className="hero-stat-label">{t('home.stats.backendNeeded')}</div>
                     </div>
                 </div>
             </section>
 
             <section className="features-section">
-                <h2 className="section-title">How It Works</h2>
+                <h2 className="section-title">{t('home.howItWorks.title')}</h2>
                 <p className="section-subtitle">
-                    Your path from zero to Soroban mastery, entirely in the browser.
+                    {t('home.howItWorks.subtitle')}
                 </p>
 
                 <div className="features-grid">
                     <div className="feature-card">
                         <div className="feature-icon cyan">📖</div>
-                        <h3>Read the Quest</h3>
-                        <p>
-                            Each mission unfolds a story while teaching core Soroban concepts.
-                            Learn about contracts, storage, tokens, and more through narrative-driven challenges.
-                        </p>
+                        <h3>{t('home.features.read.title')}</h3>
+                        <p>{t('home.features.read.body')}</p>
                     </div>
 
                     <div className="feature-card">
                         <div className="feature-icon purple">⌨️</div>
-                        <h3>Write the Code</h3>
-                        <p>
-                            Use the built-in Monaco editor with Rust syntax highlighting and
-                            Soroban autocomplete. Templates get you started — you fill in the logic.
-                        </p>
+                        <h3>{t('home.features.write.title')}</h3>
+                        <p>{t('home.features.write.body')}</p>
                     </div>
 
                     <div className="feature-card">
                         <div className="feature-icon gold">🧪</div>
-                        <h3>Run the Tests</h3>
-                        <p>
-                            Validate your code with instant feedback. Each mission has hidden checks
-                            that verify your contract structure, functions, and patterns.
-                        </p>
+                        <h3>{t('home.features.test.title')}</h3>
+                        <p>{t('home.features.test.body')}</p>
                     </div>
 
                     <div className="feature-card">
                         <div className="feature-icon cyan">🏆</div>
-                        <h3>Earn XP & Level Up</h3>
-                        <p>
-                            Gain experience points for each completed mission. Unlock badges,
-                            climb ranks, and track your journey from Initiate to Stellar Sovereign.
-                        </p>
+                        <h3>{t('home.features.xp.title')}</h3>
+                        <p>{t('home.features.xp.body')}</p>
                     </div>
 
                     <div className="feature-card">
                         <div className="feature-icon purple">🔒</div>
-                        <h3>Zero Backend</h3>
-                        <p>
-                            Everything runs in your browser. No servers, no databases, no accounts.
-                            Your progress is saved locally — export it anytime as a JSON file.
-                        </p>
+                        <h3>{t('home.features.zeroBackend.title')}</h3>
+                        <p>{t('home.features.zeroBackend.body')}</p>
                     </div>
 
                     <div className="feature-card">
                         <div className="feature-icon gold">🗺️</div>
-                        <h3>Progressive Path</h3>
-                        <p>
-                            From "Hello World" to multi-signature contracts. Each mission builds
-                            on the last, creating a structured path to Soroban mastery.
-                        </p>
+                        <h3>{t('home.features.path.title')}</h3>
+                        <p>{t('home.features.path.body')}</p>
                     </div>
                 </div>
             </section>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { loadProgress } from '../systems/storage';
-import { getAllMissions } from '../systems/missionLoader';
 import { useTranslation } from '../i18n/useTranslation';
 import { getAllMissions, isMissionUnlocked } from '../systems/missionLoader';
 import useDocumentTitle from '../systems/useDocumentTitle';

--- a/src/pages/Journal.jsx
+++ b/src/pages/Journal.jsx
@@ -1,96 +1,184 @@
 import React, { useState, useMemo } from "react";
-import { getActivityLog, ACTIVITY_TYPES, clearLog } from "../systems/activityLogger";
+import {
+  getActivityLog,
+  ACTIVITY_TYPES,
+  clearLog,
+} from "../systems/activityLogger";
 import { loadProgress } from "../systems/storage";
+import { useTranslation } from "../i18n/useTranslation";
 import "./Journal.css";
 
+// Filter chip definitions: i18n key for label + the EVENT_LABEL bucket it matches.
+const FILTER_DEFS = [
+  { id: "ALL", labelKey: "journal.filters.all", bucket: null },
+  { id: "MISSION", labelKey: "journal.filters.mission", bucket: "mission" },
+  { id: "BADGE", labelKey: "journal.filters.badge", bucket: "badge" },
+  { id: "LEVEL_UP", labelKey: "journal.filters.levelUp", bucket: "levelUp" },
+  { id: "HINT", labelKey: "journal.filters.hint", bucket: "hint" },
+  { id: "SYSTEM", labelKey: "journal.filters.system", bucket: "system" },
+];
+
+// Map each activity type to a visual bucket (icon + class + label key).
 const EVENT_CONFIG = {
-  [ACTIVITY_TYPES.MISSION_STARTED]: { icon: "⚔️", class: "mission", label: "Mission" },
-  [ACTIVITY_TYPES.MISSION_COMPLETED]: { icon: "🗡️", class: "mission", label: "Mission" },
-  [ACTIVITY_TYPES.BADGE_EARNED]: { icon: "🏅", class: "badge", label: "Badge" },
-  [ACTIVITY_TYPES.LEVEL_UP]: { icon: "⬆️", class: "level", label: "Level Up" },
-  [ACTIVITY_TYPES.HINT_USED]: { icon: "💡", class: "hint", label: "Hint" },
-  [ACTIVITY_TYPES.EXPORT]: { icon: "📤", class: "system", label: "System" },
-  [ACTIVITY_TYPES.IMPORT]: { icon: "📥", class: "system", label: "System" },
-  [ACTIVITY_TYPES.STREAK]: { icon: "🔥", class: "system", label: "Streak" },
+  [ACTIVITY_TYPES.MISSION_STARTED]: { icon: "⚔️", class: "mission", bucket: "mission" },
+  [ACTIVITY_TYPES.MISSION_COMPLETED]: { icon: "🗡️", class: "mission", bucket: "mission" },
+  [ACTIVITY_TYPES.BADGE_EARNED]: { icon: "🏅", class: "badge", bucket: "badge" },
+  [ACTIVITY_TYPES.LEVEL_UP]: { icon: "⬆️", class: "level", bucket: "levelUp" },
+  [ACTIVITY_TYPES.HINT_USED]: { icon: "💡", class: "hint", bucket: "hint" },
+  [ACTIVITY_TYPES.EXPORT]: { icon: "📤", class: "system", bucket: "system" },
+  [ACTIVITY_TYPES.IMPORT]: { icon: "📥", class: "system", bucket: "system" },
+  [ACTIVITY_TYPES.STREAK]: { icon: "🔥", class: "system", bucket: "system" },
 };
 
+/**
+ * Compose a display message from the entry's type + data using current language.
+ * Falls back to the stored legacy `message` for entries with unknown types
+ * (or persisted by older app versions before this refactor).
+ */
+function formatEventMessage(entry, t) {
+  const { type, data = {}, message } = entry;
+  switch (type) {
+    case ACTIVITY_TYPES.MISSION_STARTED:
+      return t("journal.events.missionStarted", {
+        title: data.title || data.missionId || "",
+      });
+    case ACTIVITY_TYPES.MISSION_COMPLETED:
+      return t("journal.events.missionCompleted", {
+        title: data.title || data.missionId || "",
+      });
+    case ACTIVITY_TYPES.BADGE_EARNED: {
+      // Prefer translated badge name (by id); fall back to stored name.
+      const translatedName = data.badgeId
+        ? t(`badges.${data.badgeId}.name`)
+        : null;
+      const name =
+        translatedName && translatedName !== `badges.${data.badgeId}.name`
+          ? translatedName
+          : data.badgeName || "";
+      return t("journal.events.badgeEarned", { name });
+    }
+    case ACTIVITY_TYPES.LEVEL_UP:
+      return t("journal.events.levelUp", { level: data.level });
+    case ACTIVITY_TYPES.HINT_USED:
+      return t("journal.events.hintUsed", {
+        index: (data.hintIndex ?? 0) + 1,
+      });
+    case ACTIVITY_TYPES.EXPORT:
+      return t("journal.events.export");
+    case ACTIVITY_TYPES.IMPORT:
+      return t("journal.events.import");
+    case ACTIVITY_TYPES.STREAK:
+      return t(
+        data.streak === 1
+          ? "journal.events.streakOne"
+          : "journal.events.streakMany",
+        { count: data.streak },
+      );
+    default:
+      // Unknown type — fall back to legacy stored message
+      return message || type;
+  }
+}
+
 export default function Journal() {
+  const { t, language } = useTranslation();
   const [log, setLog] = useState(() => getActivityLog());
   const [filter, setFilter] = useState("ALL");
   const progress = loadProgress();
 
   const filteredLog = useMemo(() => {
     if (filter === "ALL") return log;
-    return log.filter(entry => {
-      const config = EVENT_CONFIG[entry.type];
-      return config && config.label.toUpperCase() === filter;
+    const targetBucket = FILTER_DEFS.find((f) => f.id === filter)?.bucket;
+    if (!targetBucket) return log;
+    return log.filter((entry) => {
+      const cfg = EVENT_CONFIG[entry.type];
+      return cfg?.bucket === targetBucket;
     });
   }, [log, filter]);
 
-  // Group by date
+  // Group by date — formatted using current locale.
   const groupedLog = useMemo(() => {
     const groups = {};
-    filteredLog.forEach(entry => {
+    filteredLog.forEach((entry) => {
       const date = new Date(entry.timestamp);
-      const dateStr = formatDateHeader(date);
+      const dateStr = formatDateHeader(date, t, language);
       if (!groups[dateStr]) groups[dateStr] = [];
       groups[dateStr].push(entry);
     });
     return groups;
-  }, [filteredLog]);
+  }, [filteredLog, t, language]);
 
   const handleClear = () => {
-    if (window.confirm("Clear all activity history?")) {
+    if (window.confirm(t("journal.confirmClear"))) {
       clearLog();
       setLog([]);
     }
   };
 
+  // Locale to use for time formatting (Intl falls back gracefully if unknown)
+  const timeLocale = language === "es" ? "es" : "en";
+
   return (
     <div className="journal-page">
       <div className="journal-header flex justify-between items-end">
         <div>
-          <h1 className="journal-title">Adventure Journal</h1>
-          <p className="text-secondary">Your journey through the Soroban realm, recorded for eternity.</p>
+          <h1 className="journal-title">{t("journal.title")}</h1>
+          <p className="text-secondary">{t("journal.subtitle")}</p>
         </div>
-        <button className="btn btn-ghost btn-sm" style={{ color: "var(--red)" }} onClick={handleClear}>
-          🗑️ Clear Log
+        <button
+          className="btn btn-ghost btn-sm"
+          style={{ color: "var(--red)" }}
+          onClick={handleClear}
+        >
+          {t("journal.clearLog")}
         </button>
       </div>
 
       {/* Summary Stats */}
       <div className="adventure-summary">
         <div className="summary-stat">
-          <span className="summary-stat-value">{progress.completedMissions.length}</span>
-          <span className="summary-stat-label">Missions</span>
+          <span className="summary-stat-value">
+            {progress.completedMissions.length}
+          </span>
+          <span className="summary-stat-label">
+            {t("journal.summary.missions")}
+          </span>
         </div>
         <div className="summary-stat">
           <span className="summary-stat-value">{progress.badges.length}</span>
-          <span className="summary-stat-label">Badges</span>
+          <span className="summary-stat-label">
+            {t("journal.summary.badges")}
+          </span>
         </div>
         <div className="summary-stat">
           <span className="summary-stat-value">{progress.level}</span>
-          <span className="summary-stat-label">Level</span>
+          <span className="summary-stat-label">
+            {t("journal.summary.level")}
+          </span>
         </div>
         <div className="summary-stat">
           <span className="summary-stat-value">{progress.xp}</span>
-          <span className="summary-stat-label">Total XP</span>
+          <span className="summary-stat-label">
+            {t("journal.summary.totalXp")}
+          </span>
         </div>
         <div className="summary-stat">
           <span className="summary-stat-value">{progress.streak || 0}</span>
-          <span className="summary-stat-label">Day Streak</span>
+          <span className="summary-stat-label">
+            {t("journal.summary.streak")}
+          </span>
         </div>
       </div>
 
       {/* Filters */}
       <div className="journal-filters">
-        {["ALL", "MISSION", "BADGE", "LEVEL UP", "HINT", "SYSTEM"].map(f => (
-          <button 
-            key={f} 
-            className={`filter-chip ${filter === f ? "active" : ""}`}
-            onClick={() => setFilter(f)}
+        {FILTER_DEFS.map((f) => (
+          <button
+            key={f.id}
+            className={`filter-chip ${filter === f.id ? "active" : ""}`}
+            onClick={() => setFilter(f.id)}
           >
-            {f}
+            {t(f.labelKey)}
           </button>
         ))}
       </div>
@@ -98,18 +186,28 @@ export default function Journal() {
       {/* Timeline */}
       {Object.keys(groupedLog).length === 0 ? (
         <div className="card text-center p-12">
-          <div style={{ fontSize: "3rem", marginBottom: "1rem", opacity: 0.3 }}>📖</div>
-          <p className="text-secondary">No activities recorded yet. Start your first mission!</p>
+          <div style={{ fontSize: "3rem", marginBottom: "1rem", opacity: 0.3 }}>
+            📖
+          </div>
+          <p className="text-secondary">{t("journal.empty")}</p>
         </div>
       ) : (
         <div className="timeline">
           {Object.entries(groupedLog).map(([date, entries]) => (
             <div key={date} className="date-group">
               <div className="date-header">{date}</div>
-              {entries.map(entry => {
-                const config = EVENT_CONFIG[entry.type] || { icon: "❓", class: "system" };
-                const time = new Date(entry.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-                
+              {entries.map((entry) => {
+                const config = EVENT_CONFIG[entry.type] || {
+                  icon: "❓",
+                  class: "system",
+                };
+                const time = new Date(entry.timestamp).toLocaleTimeString(
+                  timeLocale,
+                  { hour: "2-digit", minute: "2-digit" },
+                );
+
+                const displayMessage = formatEventMessage(entry, t);
+
                 return (
                   <div key={entry.id} className="timeline-event">
                     <div className={`event-dot ${config.class}`}>
@@ -117,11 +215,16 @@ export default function Journal() {
                     </div>
                     <div className="event-content">
                       <div className="event-time">{time}</div>
-                      <div className="event-message">{entry.message}</div>
+                      <div className="event-message">{displayMessage}</div>
                       {entry.data && Object.keys(entry.data).length > 0 && (
                         <div className="event-details">
-                          {entry.type === ACTIVITY_TYPES.LEVEL_UP && `Target XP reached: ${progress.xp}`}
-                          {entry.type === ACTIVITY_TYPES.MISSION_COMPLETED && `Earned ${entry.data.xp || ""} XP`}
+                          {entry.type === ACTIVITY_TYPES.LEVEL_UP &&
+                            t("journal.details.targetXp", { xp: progress.xp })}
+                          {entry.type === ACTIVITY_TYPES.MISSION_COMPLETED &&
+                            entry.data.xp != null &&
+                            t("journal.details.earnedXp", {
+                              xp: entry.data.xp,
+                            })}
                         </div>
                       )}
                     </div>
@@ -136,23 +239,27 @@ export default function Journal() {
   );
 }
 
-function formatDateHeader(date) {
+function formatDateHeader(date, t, language) {
   const today = new Date();
   const yesterday = new Date();
   yesterday.setDate(yesterday.getDate() - 1);
 
-  if (isSameDay(date, today)) return "Today";
-  if (isSameDay(date, yesterday)) return "Yesterday";
+  if (isSameDay(date, today)) return t("journal.dates.today");
+  if (isSameDay(date, yesterday)) return t("journal.dates.yesterday");
 
-  return date.toLocaleDateString("en-US", { 
-    month: "long", 
-    day: "numeric", 
-    year: date.getFullYear() !== today.getFullYear() ? "numeric" : undefined 
+  const locale = language === "es" ? "es" : "en-US";
+  return date.toLocaleDateString(locale, {
+    month: "long",
+    day: "numeric",
+    year:
+      date.getFullYear() !== today.getFullYear() ? "numeric" : undefined,
   });
 }
 
 function isSameDay(d1, d2) {
-  return d1.getFullYear() === d2.getFullYear() &&
-         d1.getMonth() === d2.getMonth() &&
-         d1.getDate() === d2.getDate();
+  return (
+    d1.getFullYear() === d2.getFullYear() &&
+    d1.getMonth() === d2.getMonth() &&
+    d1.getDate() === d2.getDate()
+  );
 }

--- a/src/pages/MissionDetail.jsx
+++ b/src/pages/MissionDetail.jsx
@@ -5,7 +5,7 @@ import ReactMarkdown from "react-markdown";
 import { getMissionById, getNextMission } from "../systems/missionLoader";
 import { runTests } from "../systems/testRunner";
 import { loadProgress, saveProgress } from "../systems/storage";
-import { completeMission, recordAttempt, getRankTitle } from "../systems/gameEngine";
+import { completeMission, recordAttempt } from "../systems/gameEngine";
 import { logActivity, ACTIVITY_TYPES } from "../systems/activityLogger";
 import MissionDetailSkeleton from "../components/MissionDetailSkeleton";
 import { useokashi, TOAST_STATES } from "../systems/useokashi";
@@ -14,14 +14,17 @@ import { useToast } from "../systems/ToastContext";
 import { MissionErrorBoundary } from "../components/ErrorBoundary";
 import CodeReplayPlayer from "../components/CodeReplayPlayer";
 import CodeRecorder from "../systems/codeRecorder";
+import { useTranslation } from "../i18n/useTranslation";
 
 // ─── Monaco marker model name (must be consistent across calls) ──────────────
 const LIVE_MARKER_OWNER = "soroban-quest-live";
+const MAX_RANK_INDEX = 10;
 
 export default function MissionDetail() {
   const { missionId } = useParams();
   const navigate = useNavigate();
-  const mission = getMissionById(missionId);
+  const { t, language } = useTranslation();
+  const mission = getMissionById(missionId, language);
 
   // Safe fallback in case ToastContext is not provided
   const toastContext = useToast();
@@ -66,7 +69,13 @@ export default function MissionDetail() {
         setLivePassCount(0);
         setLiveTotalCount(0);
         setLoading(false);
-        logActivity(ACTIVITY_TYPES.MISSION_STARTED, { missionId, title: mission.title }, `Started mission: ${mission.title}`);
+        // Keep stored message in English for log durability; Journal will
+        // re-compose the displayed string via t() at render time using `data`.
+        logActivity(
+          ACTIVITY_TYPES.MISSION_STARTED,
+          { missionId, title: mission.title },
+          `Started mission: ${mission.title}`,
+        );
       }, 1500);
     } else {
       setLoading(false);
@@ -129,7 +138,7 @@ export default function MissionDetail() {
   function statusBarState() {
     if (liveTotalCount === 0) {
       return {
-        label: "Checking…",
+        label: t("missionDetail.status.checking"),
         color: "var(--text-muted)",
         barColor: "rgba(255,255,255,0.08)",
         pct: 0,
@@ -138,24 +147,22 @@ export default function MissionDetail() {
     const pct = Math.round((livePassCount / liveTotalCount) * 100);
     if (livePassCount === liveTotalCount) {
       return {
-        label: `${livePassCount}/${liveTotalCount} checks passing ✓`,
+        label: t("missionDetail.status.allPassing", {
+          passed: livePassCount,
+          total: liveTotalCount,
+        }),
         color: "#34d399",
         barColor: "#059669",
         pct,
       };
     }
-    if (livePassCount === 0) {
-      return {
-        label: `${livePassCount}/${liveTotalCount} checks passing`,
-        color: "#f87171",
-        barColor: "#dc2626",
-        pct,
-      };
-    }
     return {
-      label: `${livePassCount}/${liveTotalCount} checks passing`,
-      color: "#fbbf24",
-      barColor: "#d97706",
+      label: t("missionDetail.status.passing", {
+        passed: livePassCount,
+        total: liveTotalCount,
+      }),
+      color: livePassCount === 0 ? "#f87171" : "#fbbf24",
+      barColor: livePassCount === 0 ? "#dc2626" : "#d97706",
       pct,
     };
   }
@@ -176,7 +183,7 @@ export default function MissionDetail() {
       setTestResults([...resultCollector]);
     };
 
-    addResult({ phase: "info", message: "🔍 Running validation checks..." });
+    addResult({ phase: "info", message: t("missionDetail.terminal.runningChecks") });
     await delay(400);
 
     const result = await runTests(code, mission);
@@ -189,7 +196,7 @@ export default function MissionDetail() {
     addResult({ phase: "summary", message: result.summary });
 
     if (result.allPassed) {
-      if (showToast) showToast("Mission Parameters Validated!", "success");
+      if (showToast) showToast(t("missionDetail.toasts.validated"), "success");
       await delay(500);
       state = loadProgress();
       const newState = completeMission(state, missionId, mission.xpReward);
@@ -206,23 +213,32 @@ export default function MissionDetail() {
       } else {
         addResult({
           phase: "info",
-          message: "🏅 Already completed — no additional XP awarded.",
+          message: t("missionDetail.terminal.alreadyCompleted"),
         });
       }
     } else {
-      if (showToast) showToast("Validation failed. Check terminal.", "error");
+      if (showToast) showToast(t("missionDetail.toasts.validationFailed"), "error");
     }
 
     setIsRunning(false);
-  }, [code, mission, missionId, isRunning, showToast]);
+  }, [code, mission, missionId, isRunning, showToast, t]);
 
   // --------------------------- Hints ---------------------------
   const handleHint = () => {
     if (mission?.hints && hintIndex < mission.hints.length - 1) {
       const nextIndex = hintIndex + 1;
       setHintIndex(nextIndex);
-      if (showToast) showToast(`Hint ${nextIndex + 1} unlocked`, "info");
-      logActivity(ACTIVITY_TYPES.HINT_USED, { missionId, hintIndex: nextIndex }, `Used hint ${nextIndex + 1} for ${mission.title}`);
+      if (showToast) {
+        showToast(
+          t("missionDetail.toasts.hintUnlocked", { index: nextIndex + 1 }),
+          "info",
+        );
+      }
+      logActivity(
+        ACTIVITY_TYPES.HINT_USED,
+        { missionId, hintIndex: nextIndex, title: mission.title },
+        `Used hint ${nextIndex + 1} for ${mission.title}`,
+      );
     }
   };
 
@@ -232,7 +248,7 @@ export default function MissionDetail() {
       setCode(mission.template);
       setTestResults([]);
       setHintIndex(-1);
-      if (showToast) showToast("Code reset to template", "warning");
+      if (showToast) showToast(t("missionDetail.toasts.codeReset"), "warning");
     }
   };
 
@@ -240,13 +256,13 @@ export default function MissionDetail() {
   const handleShowSolution = () => {
     if (mission?.solution) {
       setCode(mission.solution);
-      if (showToast) showToast("Solution loaded into editor", "info");
+      if (showToast) showToast(t("missionDetail.toasts.solutionLoaded"), "info");
     }
   };
 
   // --------------------------- Navigate to Next Mission ---------------------------
   const handleNextMission = () => {
-    const next = getNextMission(missionId);
+    const next = getNextMission(missionId, language);
     if (next) navigate(`/mission/${next.id}`);
     else navigate("/missions");
   };
@@ -272,22 +288,25 @@ export default function MissionDetail() {
   if (!mission) {
     return (
       <div style={{ padding: "4rem", textAlign: "center" }}>
-        <h2>Mission Not Found</h2>
+        <h2>{t("missionDetail.notFound.title")}</h2>
         <p style={{ color: "var(--text-secondary)", marginTop: "1rem" }}>
-          The mission "{missionId}" doesn't exist.
+          {t("missionDetail.notFound.body", { id: missionId })}
         </p>
         <button
           className="btn btn-primary"
           onClick={() => navigate("/missions")}
           style={{ marginTop: "1.5rem" }}
         >
-          ← Back to Mission Map
+          {t("missionDetail.notFound.back")}
         </button>
       </div>
     );
   }
 
   const sbState = statusBarState();
+  const victoryRank = victoryData
+    ? t(`ranks.${Math.min(Math.max(victoryData.newLevel - 1, 0), MAX_RANK_INDEX)}`)
+    : "";
 
   // --------------------------- Render Mission Detail ---------------------------
   if (showReplay) {
@@ -333,11 +352,11 @@ export default function MissionDetail() {
       )}
 
       <div className="mobile-tabs">
-        <label htmlFor="tab-story">Story</label>
-        <label htmlFor="tab-editor">Editor</label>
-        <label htmlFor="tab-tests">Tests</label>
+        <label htmlFor="tab-story">{t("missionDetail.tabs.story")}</label>
+        <label htmlFor="tab-editor">{t("missionDetail.tabs.editor")}</label>
+        <label htmlFor="tab-tests">{t("missionDetail.tabs.tests")}</label>
         {isCompleted && hasReplay && (
-          <label htmlFor="tab-replay">📹 Replay</label>
+          <label htmlFor="tab-replay">{t("missionDetail.tabs.replay")}</label>
         )}
       </div>
 
@@ -346,12 +365,13 @@ export default function MissionDetail() {
         <div className="mission-story">
           <div style={{ marginBottom: "var(--space-md)" }}>
             <span className={`badge badge-${mission.difficulty}`}>
-              {mission.difficulty}
+              {t(`difficulty.${mission.difficulty}`)}
             </span>
             <span className="mission-card-xp" style={{ marginLeft: "0.5rem" }}>
-              ⚡ {mission.xpReward} XP
+              {t("missionMap.card.xp", { xp: mission.xpReward })}
             </span>
           </div>
+          {/* Story is localized via the mission data file (Phase 3). */}
           <ReactMarkdown>{mission.story}</ReactMarkdown>
 
           {hintIndex >= 0 && (
@@ -365,7 +385,7 @@ export default function MissionDetail() {
               }}
             >
               <strong style={{ color: "var(--gold)" }}>
-                💡 Hint {hintIndex + 1}:
+                {t("missionDetail.hint.label", { index: hintIndex + 1 })}
               </strong>
               <p
                 style={{
@@ -394,7 +414,7 @@ export default function MissionDetail() {
                 onClick={handleReset}
                 disabled={isRunning}
               >
-                ↺ Reset
+                {t("missionDetail.editor.reset")}
               </button>
               <button
                 className="btn btn-ghost btn-sm"
@@ -403,20 +423,20 @@ export default function MissionDetail() {
                   !mission.hints || hintIndex >= mission.hints.length - 1
                 }
               >
-                💡 Hint
+                {t("missionDetail.editor.hint")}
               </button>
               <button
                 className="btn btn-ghost btn-sm"
                 onClick={handleShowSolution}
               >
-                👁️ Solution
+                {t("missionDetail.editor.solution")}
               </button>
               <button
                 className="btn btn-primary btn-sm"
                 onClick={handleRunTests}
                 disabled={isRunning}
               >
-                {isRunning ? "Running..." : "▶ Run Tests"}
+                {isRunning ? t("missionDetail.editor.running") : t("missionDetail.editor.run")}
               </button>
             </div>
           </div>
@@ -490,7 +510,7 @@ export default function MissionDetail() {
                 |
               </span>
               <span style={{ color: "rgba(255,255,255,0.3)", fontSize: "10.5px" }}>
-                live checks · full suite on Run Tests
+                {t("missionDetail.status.note")}
               </span>
             </div>
           )}
@@ -509,7 +529,7 @@ export default function MissionDetail() {
                 <span className="terminal-dot red" />
                 <span className="terminal-dot yellow" />
                 <span className="terminal-dot green" />
-                <span className="terminal-title">Test Output</span>
+                <span className="terminal-title">{t("missionDetail.terminal.title")}</span>
               </div>
               <div
                 className="terminal-body"
@@ -521,7 +541,7 @@ export default function MissionDetail() {
                     className="terminal-line info"
                     style={{ color: "var(--text-muted)" }}
                   >
-                    Click "Run Tests" to validate your code...
+                    {t("missionDetail.terminal.placeholder")}
                   </span>
                 ) : (
                   testResults.map((r, i) => (
@@ -554,17 +574,17 @@ export default function MissionDetail() {
             borderTop: '1px solid var(--border-subtle)'
           }}>
             <h3 style={{ marginBottom: '1rem', color: 'var(--text-primary)' }}>
-              📹 Watch Your Solution
+              {t("missionDetail.replay.header")}
             </h3>
             <p style={{ color: 'var(--text-secondary)', marginBottom: '1.5rem' }}>
-              Review your problem-solving process step by step.
+              {t("missionDetail.replay.body")}
             </p>
             <button
               className="btn btn-primary"
               onClick={handleWatchReplay}
               style={{ fontSize: '1rem', padding: '0.75rem 2rem' }}
             >
-              ▶️ Start Replay
+              {t("missionDetail.replay.start")}
             </button>
           </div>
         )}
@@ -575,11 +595,11 @@ export default function MissionDetail() {
         <div className="modal-overlay" onClick={() => setShowVictory(false)}>
           <div className="modal-content" onClick={(e) => e.stopPropagation()}>
             <div className="modal-icon">🏆</div>
-            <h2 className="modal-title">Mission Complete!</h2>
+            <h2 className="modal-title">{t("missionDetail.victory.title")}</h2>
             <p className="modal-message">
-              You've completed <strong>{mission.title}</strong>
+              {t("missionDetail.victory.youCompleted")} <strong>{mission.title}</strong>
             </p>
-            <div className="modal-xp">+{victoryData.xp} XP</div>
+            <div className="modal-xp">{t("missionDetail.victory.xpGained", { xp: victoryData.xp })}</div>
 
             {victoryData.leveledUp && (
               <p
@@ -589,14 +609,18 @@ export default function MissionDetail() {
                   marginBottom: "1rem",
                 }}
               >
-                🎉 Level Up! You are now Level {victoryData.newLevel} —{" "}
-                {getRankTitle(victoryData.newLevel)}
+                {t("missionDetail.victory.levelUp", {
+                  level: victoryData.newLevel,
+                  rank: victoryRank,
+                })}
               </p>
             )}
 
             {victoryData.newBadges?.length > 0 && (
               <p style={{ color: "var(--gold)", marginBottom: "1rem" }}>
-                🏅 New badge{victoryData.newBadges.length > 1 ? "s" : ""} earned!
+                {victoryData.newBadges.length > 1
+                  ? t("missionDetail.victory.badgeEarnedMany")
+                  : t("missionDetail.victory.badgeEarnedOne")}
               </p>
             )}
 
@@ -608,13 +632,13 @@ export default function MissionDetail() {
               }}
             >
               <button className="btn btn-primary" onClick={handleNextMission}>
-                Next Mission →
+                {t("missionDetail.victory.next")}
               </button>
               <button
                 className="btn btn-secondary"
                 onClick={() => navigate("/missions")}
               >
-                Mission Map
+                {t("missionDetail.victory.map")}
               </button>
             </div>
 
@@ -631,7 +655,7 @@ export default function MissionDetail() {
               }}
             >
               <button onClick={() => openInOkashi(code)} className="okashi-btn">
-                🚀 Try on Okashi — Compile & Deploy
+                {t("missionDetail.okashi.button")}
               </button>
 
               <p
@@ -644,9 +668,7 @@ export default function MissionDetail() {
                   lineHeight: "1.5",
                 }}
               >
-                Opens okashi.dev in a new tab. Your code is copied to clipboard
-                — paste it there to compile with the real Soroban compiler and
-                deploy to Testnet.
+                {t("missionDetail.okashi.help")}
               </p>
 
               {toast?.state !== TOAST_STATES.IDLE && (

--- a/src/pages/MissionMap.jsx
+++ b/src/pages/MissionMap.jsx
@@ -2,11 +2,13 @@ import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { loadProgress } from '../systems/storage';
 import { getAllMissions, isMissionUnlocked } from '../systems/missionLoader';
+import { useTranslation } from '../i18n/useTranslation';
 
 export default function MissionMap() {
     const navigate = useNavigate();
     const state = loadProgress();
-    const missions = getAllMissions();
+    const { t, language } = useTranslation();
+    const missions = useMemo(() => getAllMissions(language), [language]);
     const learningPathRef = useRef(null);
     const [learningPathWidth, setLearningPathWidth] = useState(800);
     const [searchTerm, setSearchTerm] = useState('');
@@ -19,7 +21,7 @@ export default function MissionMap() {
             completed: state.completedMissions.includes(m.id),
             unlocked: isMissionUnlocked(m.id, state.completedMissions),
         }));
-    }, [state.completedMissions]);
+    }, [missions, state.completedMissions]);
 
     const filteredMissions = useMemo(() => {
         return missionStates.filter((mission) => {
@@ -36,6 +38,12 @@ export default function MissionMap() {
         if (mission.unlocked) {
             navigate(`/mission/${mission.id}`);
         }
+    };
+
+    const ariaLabelFor = (m) => {
+        if (m.completed) return t('missionMap.aria.missionItemCompleted', { order: m.order, title: m.title });
+        if (m.unlocked) return t('missionMap.aria.missionItemUnlocked', { order: m.order, title: m.title });
+        return t('missionMap.aria.missionItemLocked', { order: m.order, title: m.title });
     };
 
     useEffect(() => {
@@ -97,9 +105,12 @@ export default function MissionMap() {
     return (
         <div className="mission-map-page">
             <div className="mission-map-header">
-                <h1 className="section-title">Mission Map</h1>
+                <h1 className="section-title">{t('missionMap.title')}</h1>
                 <p className="section-subtitle">
-                    {state.completedMissions.length} of {missions.length} missions completed
+                    {t('missionMap.subtitle', {
+                        completed: state.completedMissions.length,
+                        total: missions.length,
+                    })}
                 </p>
             </div>
 
@@ -110,7 +121,7 @@ export default function MissionMap() {
                     fill="none"
                     xmlns="http://www.w3.org/2000/svg"
                     role="img"
-                    aria-label="Mission path graph"
+                    aria-label={t('missionMap.aria.missionPath')}
                 >
                     {desktopPathLayout.points.map(({ mission, cx, cy, index }) => {
                         const next = desktopPathLayout.points[index + 1];
@@ -144,7 +155,7 @@ export default function MissionMap() {
                                     }}
                                     role={mission.unlocked ? 'button' : undefined}
                                     tabIndex={mission.unlocked ? 0 : -1}
-                                    aria-label={`Mission ${mission.order}: ${mission.title}`}
+                                    aria-label={t('missionMap.aria.missionItem', { order: mission.order, title: mission.title })}
                                     style={{ cursor: mission.unlocked ? 'pointer' : 'not-allowed' }}
                                 >
                                     <circle className="path-node-hit-area" cx={cx} cy={cy} r="28" fill="transparent" />
@@ -160,36 +171,24 @@ export default function MissionMap() {
                                     />
                                     <text
                                         x={cx}
-                                        y={cy + 1}
+                                        y={cy + 4}
                                         textAnchor="middle"
-                                        dominantBaseline="middle"
-                                        fill={mission.completed ? '#22c55e' : mission.unlocked ? '#06d6a0' : '#6b7280'}
-                                        fontSize="14"
-                                        fontWeight="bold"
+                                        fontSize="11"
+                                        fontWeight="700"
+                                        fill={textColor}
+                                        fontFamily="'JetBrains Mono', monospace"
                                     >
                                         {mission.completed ? '✓' : mission.unlocked ? mission.order : '🔒'}
                                     </text>
                                     <text
                                         x={cx}
-                                        y={cy + 42}
+                                        y={cy + 44}
                                         textAnchor="middle"
-                                        fill={textColor}
                                         fontSize="11"
+                                        fill={mission.unlocked ? '#cbd5e1' : '#475569'}
                                         fontWeight="500"
-                                        fontFamily="Inter, sans-serif"
                                     >
                                         {shortTitle}
-                                    </text>
-                                    <text
-                                        x={cx}
-                                        y={cy + 56}
-                                        textAnchor="middle"
-                                        fill={mission.completed ? '#22c55e' : '#f59e0b'}
-                                        fontSize="9"
-                                        fontWeight="600"
-                                        fontFamily="Orbitron, sans-serif"
-                                    >
-                                        {mission.completed ? 'COMPLETED' : `${mission.xpReward} XP`}
                                     </text>
                                 </g>
                             </g>
@@ -211,7 +210,7 @@ export default function MissionMap() {
                     </defs>
                 </svg>
             </div>
-            <div className="learning-path-mobile" aria-label="Mission timeline">
+            <div className="learning-path-mobile" aria-label={t('missionMap.aria.missionTimeline')}>
                 {filteredMissions.map((m, i) => (
                     <button
                         type="button"
@@ -219,7 +218,7 @@ export default function MissionMap() {
                         className={`timeline-item ${m.completed ? 'completed' : ''} ${!m.unlocked ? 'locked' : ''}`}
                         onClick={() => handleMissionClick(m)}
                         disabled={!m.unlocked}
-                        aria-label={`Mission ${m.order}: ${m.title}${m.completed ? ', completed' : m.unlocked ? ', unlocked' : ', locked'}`}
+                        aria-label={ariaLabelFor(m)}
                     >
                         <span className="timeline-track" aria-hidden="true">
                             <span className="timeline-node">
@@ -231,12 +230,12 @@ export default function MissionMap() {
                         </span>
                         <span className="timeline-body">
                             <span className="timeline-meta">
-                                Chapter {m.chapter} • Mission {m.order}
+                                {t('missionMap.card.chapterMission', { chapter: m.chapter, mission: m.order })}
                             </span>
                             <span className="timeline-title">{m.title}</span>
                             <span className="timeline-foot">
-                                <span className="timeline-xp">⚡ {m.xpReward} XP</span>
-                                <span className={`badge badge-${m.difficulty}`}>{m.difficulty}</span>
+                                <span className="timeline-xp">{t('missionMap.card.xp', { xp: m.xpReward })}</span>
+                                <span className={`badge badge-${m.difficulty}`}>{t(`difficulty.${m.difficulty}`)}</span>
                             </span>
                         </span>
                     </button>
@@ -248,7 +247,7 @@ export default function MissionMap() {
                 <div className="search-bar">
                     <input
                         type="text"
-                        placeholder="Search missions..."
+                        placeholder={t('missionMap.searchPlaceholder')}
                         value={searchTerm}
                         onChange={(e) => setSearchTerm(e.target.value)}
                         className="search-input"
@@ -260,25 +259,25 @@ export default function MissionMap() {
                             className={`filter-chip ${selectedDifficulty === 'all' ? 'active' : ''}`}
                             onClick={() => setSelectedDifficulty('all')}
                         >
-                            All
+                            {t('missionMap.difficulty.all')}
                         </button>
                         <button
                             className={`filter-chip ${selectedDifficulty === 'beginner' ? 'active' : ''}`}
                             onClick={() => setSelectedDifficulty('beginner')}
                         >
-                            Beginner
+                            {t('missionMap.difficulty.beginner')}
                         </button>
                         <button
                             className={`filter-chip ${selectedDifficulty === 'intermediate' ? 'active' : ''}`}
                             onClick={() => setSelectedDifficulty('intermediate')}
                         >
-                            Intermediate
+                            {t('missionMap.difficulty.intermediate')}
                         </button>
                         <button
                             className={`filter-chip ${selectedDifficulty === 'advanced' ? 'active' : ''}`}
                             onClick={() => setSelectedDifficulty('advanced')}
                         >
-                            Advanced
+                            {t('missionMap.difficulty.advanced')}
                         </button>
                     </div>
                     <div className="chapter-filters">
@@ -286,33 +285,24 @@ export default function MissionMap() {
                             className={`filter-chip ${selectedChapter === 'all' ? 'active' : ''}`}
                             onClick={() => setSelectedChapter('all')}
                         >
-                            All Chapters
+                            {t('missionMap.chapters.all')}
                         </button>
-                        <button
-                            className={`filter-chip ${selectedChapter === 1 ? 'active' : ''}`}
-                            onClick={() => setSelectedChapter(1)}
-                        >
-                            Chapter 1
-                        </button>
-                        <button
-                            className={`filter-chip ${selectedChapter === 2 ? 'active' : ''}`}
-                            onClick={() => setSelectedChapter(2)}
-                        >
-                            Chapter 2
-                        </button>
-                        <button
-                            className={`filter-chip ${selectedChapter === 3 ? 'active' : ''}`}
-                            onClick={() => setSelectedChapter(3)}
-                        >
-                            Chapter 3
-                        </button>
+                        {[1, 2, 3].map((n) => (
+                            <button
+                                key={n}
+                                className={`filter-chip ${selectedChapter === n ? 'active' : ''}`}
+                                onClick={() => setSelectedChapter(n)}
+                            >
+                                {t('missionMap.chapters.n', { number: n })}
+                            </button>
+                        ))}
                     </div>
                 </div>
             </div>
             <div className="mission-map-grid">
                 {filteredMissions.length === 0 ? (
                     <div className="no-missions-found">
-                        <p>No missions found matching your filters.</p>
+                        <p>{t('missionMap.noResults')}</p>
                     </div>
                 ) : (
                     filteredMissions.map((m) => (
@@ -322,8 +312,10 @@ export default function MissionMap() {
                             onClick={() => handleMissionClick(m)}
                         >
                             <div className="mission-card-header">
-                                <span className="mission-card-chapter">Chapter {m.chapter} • Mission {m.order}</span>
-                                <span className="mission-card-xp">⚡ {m.xpReward} XP</span>
+                                <span className="mission-card-chapter">
+                                    {t('missionMap.card.chapterMission', { chapter: m.chapter, mission: m.order })}
+                                </span>
+                                <span className="mission-card-xp">{t('missionMap.card.xp', { xp: m.xpReward })}</span>
                             </div>
                             <h3 className="mission-card-title">{m.title}</h3>
                             <p className="mission-card-desc">{m.learningGoal}</p>
@@ -334,14 +326,14 @@ export default function MissionMap() {
                                     ))}
                                 </div>
                                 <span className={`badge badge-${m.difficulty}`}>
-                                    {m.difficulty}
+                                    {t(`difficulty.${m.difficulty}`)}
                                 </span>
                             </div>
                             {m.completed && (
-                                <div className="mission-card-status completed">✓ Completed</div>
+                                <div className="mission-card-status completed">{t('missionMap.card.completed')}</div>
                             )}
                             {!m.unlocked && (
-                                <div className="mission-card-status" style={{ color: 'var(--text-muted)' }}>🔒 Locked</div>
+                                <div className="mission-card-status" style={{ color: 'var(--text-muted)' }}>{t('missionMap.card.locked')}</div>
                             )}
                         </div>
                     ))

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,15 +1,18 @@
 import { Link } from "react-router-dom";
+import { useTranslation } from "../i18n/useTranslation";
 
 const NotFound = () => {
+  const { t } = useTranslation();
+
   return (
     <div className="notfound-container">
       <div className="notfound-card">
         <h1>404</h1>
-        <h2>This quest does not exist</h2>
-        <p>You seem to have wandered into deep space</p>
+        <h2>{t("notFound.title")}</h2>
+        <p>{t("notFound.body")}</p>
 
         <Link to="/" className="home-btn">
-          Return to Base
+          {t("notFound.back")}
         </Link>
       </div>
     </div>

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -9,15 +9,19 @@ import {
   saveProfile,
 } from "../systems/storage";
 
-import { getXPProgress, getRankTitle, BADGES } from "../systems/gameEngine";
+import { getXPProgress, BADGES } from "../systems/gameEngine";
 import { getAllMissions } from "../systems/missionLoader";
 import { avatars } from "../data/avatars";
 import { logActivity, ACTIVITY_TYPES } from "../systems/activityLogger";
+import { useTranslation } from "../i18n/useTranslation";
+
+// Total rank entries: 0..10. Anything >= 10 maps to the last rank.
+const MAX_RANK_INDEX = 10;
 
 export default function Profile() {
-  const [state, setState] = useState(loadProgress());
+  const { t, language } = useTranslation();
 
-  // ✅ IMPORTANT: safe profile init
+  const [state, setState] = useState(loadProgress());
   const [profile, setProfile] = useState(() => loadProfile());
 
   const [editing, setEditing] = useState(false);
@@ -28,8 +32,9 @@ export default function Profile() {
   const fileInputRef = useRef(null);
 
   const xpProgress = getXPProgress(state);
-  const rankTitle = getRankTitle(state.level);
-  const missions = getAllMissions();
+  const rankIndex = Math.min(Math.max(state.level - 1, 0), MAX_RANK_INDEX);
+  const rankTitle = t(`ranks.${rankIndex}`);
+  const missions = getAllMissions(language);
 
   /* ---------------- SAVE PROFILE ---------------- */
   const saveUserProfile = () => {
@@ -53,8 +58,8 @@ export default function Profile() {
   /* ---------------- PROGRESS ACTIONS ---------------- */
   const handleExport = () => {
     exportProgress();
-    setImportStatus("✅ Progress exported!");
-    logActivity(ACTIVITY_TYPES.EXPORT, {}, "Exported adventure progress");
+    setImportStatus(t("profile.data.status.exported"));
+    logActivity(ACTIVITY_TYPES.EXPORT, {}, t("profile.data.log.exported"));
     setTimeout(() => setImportStatus(""), 3000);
   };
 
@@ -65,20 +70,20 @@ export default function Profile() {
     try {
       const newState = await importProgress(file);
       setState(newState);
-      setImportStatus("✅ Progress imported successfully!");
-      logActivity(ACTIVITY_TYPES.IMPORT, {}, "Imported adventure progress from file");
+      setImportStatus(t("profile.data.status.imported"));
+      logActivity(ACTIVITY_TYPES.IMPORT, {}, t("profile.data.log.imported"));
     } catch {
-      setImportStatus("❌ Invalid file — could not import.");
+      setImportStatus(t("profile.data.status.importFailed"));
     }
 
     setTimeout(() => setImportStatus(""), 3000);
   };
 
   const handleReset = () => {
-    if (window.confirm("Reset all progress? This cannot be undone.")) {
+    if (window.confirm(t("profile.data.confirmReset"))) {
       const newState = resetProgress();
       setState(newState);
-      setImportStatus("🗑️ Progress reset.");
+      setImportStatus(t("profile.data.status.resetDone"));
       setTimeout(() => setImportStatus(""), 3000);
     }
   };
@@ -110,19 +115,22 @@ export default function Profile() {
 
             <div className="xp-bar-label">
               <span>
-                {xpProgress.current} / {xpProgress.needed} XP
+                {t("profile.xpBar.current", {
+                  current: xpProgress.current,
+                  needed: xpProgress.needed,
+                })}
               </span>
-              <span>Total: {state.xp} XP</span>
+              <span>{t("profile.xpBar.total", { xp: state.xp })}</span>
             </div>
           </div>
 
           {/* ACTIONS */}
           <div className="flex gap-2 mt-3">
             <button className="btn btn-secondary" onClick={openEdit}>
-              ✏️ Edit Profile
+              {t("profile.edit")}
             </button>
             <Link to="/journal" className="btn btn-ghost">
-              📖 View Journal
+              {t("profile.viewJournal")}
             </Link>
           </div>
         </div>
@@ -136,7 +144,7 @@ export default function Profile() {
               {state.completedMissions.length}
             </div>
             <div style={{ fontSize: "0.7rem", color: "var(--text-muted)" }}>
-              Missions
+              {t("profile.stats.missions")}
             </div>
           </div>
 
@@ -145,7 +153,7 @@ export default function Profile() {
               {state.badges.length}
             </div>
             <div style={{ fontSize: "0.7rem", color: "var(--text-muted)" }}>
-              Badges
+              {t("profile.stats.badges")}
             </div>
           </div>
         </div>
@@ -154,15 +162,18 @@ export default function Profile() {
       {/* EDIT PANEL */}
       {editing && (
         <div className="card mt-4">
-          <h3 className="mb-3">Edit Profile</h3>
+          <h3 className="mb-3">{t("profile.editPanel.title")}</h3>
 
           {/* NAME */}
           <input
             className="w-full p-2 mb-3 rounded"
-            style={{ backgroundColor: "var(--bg-secondary)", color: "var(--text-primary)" }}
+            style={{
+              backgroundColor: "var(--bg-secondary)",
+              color: "var(--text-primary)",
+            }}
             value={name}
             onChange={(e) => setName(e.target.value)}
-            placeholder="Enter name"
+            placeholder={t("profile.editPanel.namePlaceholder")}
           />
 
           {/* AVATARS */}
@@ -173,7 +184,8 @@ export default function Profile() {
                 onClick={() => setAvatar(a)}
                 className="text-2xl p-2 rounded transition"
                 style={{
-                  backgroundColor: avatar === a ? "var(--cyan-dim)" : "var(--bg-glass)",
+                  backgroundColor:
+                    avatar === a ? "var(--cyan-dim)" : "var(--bg-glass)",
                   transform: avatar === a ? "scale(1.1)" : "none",
                 }}
               >
@@ -185,18 +197,18 @@ export default function Profile() {
           {/* ACTIONS */}
           <div className="flex gap-2">
             <button className="btn btn-primary" onClick={saveUserProfile}>
-              Save
+              {t("common.save")}
             </button>
 
             <button className="btn btn-ghost" onClick={() => setEditing(false)}>
-              Cancel
+              {t("common.cancel")}
             </button>
           </div>
         </div>
       )}
 
       {/* BADGES */}
-      <h2 className="profile-section-title">🏅 Badges</h2>
+      <h2 className="profile-section-title">{t("profile.sections.badges")}</h2>
 
       <div className="profile-badges-grid">
         {BADGES.map((badge) => {
@@ -209,8 +221,8 @@ export default function Profile() {
             >
               <div className="profile-badge-icon">{badge.icon}</div>
               <div className="profile-badge-info">
-                <h4>{badge.name}</h4>
-                <p>{badge.description}</p>
+                <h4>{t(`badges.${badge.id}.name`)}</h4>
+                <p>{t(`badges.${badge.id}.description`)}</p>
               </div>
             </div>
           );
@@ -218,10 +230,12 @@ export default function Profile() {
       </div>
 
       {/* MISSIONS */}
-      <h2 className="profile-section-title">✅ Completed Missions</h2>
+      <h2 className="profile-section-title">
+        {t("profile.sections.completedMissions")}
+      </h2>
 
       {completedMissions.length === 0 ? (
-        <div className="card text-center p-6">No missions completed yet.</div>
+        <div className="card text-center p-6">{t("profile.noMissions")}</div>
       ) : (
         completedMissions.map((m) => (
           <div key={m.id} className="card flex justify-between">
@@ -232,22 +246,26 @@ export default function Profile() {
       )}
 
       {/* DATA */}
-      <h2 className="profile-section-title">⚙️ Data</h2>
+      <h2 className="profile-section-title">{t("profile.sections.data")}</h2>
 
       <div className="profile-actions">
         <button className="btn btn-secondary" onClick={handleExport}>
-          Export
+          {t("profile.data.export")}
         </button>
 
         <button
           className="btn btn-secondary"
           onClick={() => fileInputRef.current?.click()}
         >
-          Import
+          {t("profile.data.import")}
         </button>
 
-        <button className="btn btn-ghost" style={{ color: "var(--red)" }} onClick={handleReset}>
-          Reset
+        <button
+          className="btn btn-ghost"
+          style={{ color: "var(--red)" }}
+          onClick={handleReset}
+        >
+          {t("profile.data.reset")}
         </button>
 
         <input

--- a/src/pages/SkillTree.jsx
+++ b/src/pages/SkillTree.jsx
@@ -1,40 +1,40 @@
-import React, { useState, useEffect } from 'react';
-import { missions } from '../data/missions';
+import React, { useState, useEffect, useMemo } from 'react';
+import { missions, localizeMissions } from '../data/missions';
 import { loadProgress } from '../systems/storage';
+import { useTranslation } from '../i18n/useTranslation';
 import './SkillTree.css';
 
+// Concept identifiers are kept untranslated — they're code-level tokens
+// (e.g. `contract`, `Env`, `require_auth`) that appear verbatim in Rust.
+// Only the category titles/descriptions and surrounding chrome are localized.
 const conceptCategories = {
   Core: {
-    title: 'Core Concepts',
-    description: 'Fundamental Soroban building blocks',
     concepts: ['contract', 'contractimpl', 'Env', 'Symbol']
   },
   Storage: {
-    title: 'Storage & State',
-    description: 'Managing persistent data',
     concepts: ['storage', 'instance', 'persistent storage', 'set', 'get', 'remove', 'unwrap_or']
   },
   Types: {
-    title: 'Data Types',
-    description: 'Working with different data types',
     concepts: ['Address', 'Vec', 'Map', 'String', 'i128', 'u32', 'bool']
   },
   Auth: {
-    title: 'Authorization',
-    description: 'Access control and security',
     concepts: ['require_auth', 'init pattern', 'admin patterns']
   },
   Advanced: {
-    title: 'Advanced Patterns',
-    description: 'Complex contract patterns',
     concepts: ['token', 'mint', 'transfer', 'ledger sequence', 'time-lock', 'multi-sig', 'governance pattern', 'conditional panic', 'complex state', 'multiple functions']
   }
 };
 
 export default function SkillTree() {
+  const { t, language } = useTranslation();
   const [completedMissions, setCompletedMissions] = useState([]);
   const [selectedConcept, setSelectedConcept] = useState(null);
   const [hoveredConcept, setHoveredConcept] = useState(null);
+
+  const localizedMissions = useMemo(
+    () => localizeMissions(missions, language),
+    [language],
+  );
 
   useEffect(() => {
     const progress = loadProgress();
@@ -42,12 +42,12 @@ export default function SkillTree() {
   }, []);
 
   const getConceptStatus = (concept) => {
-    const teachingMission = missions.find(mission => 
+    const teachingMission = localizedMissions.find(mission =>
       mission.conceptsIntroduced?.includes(concept)
     );
-    
+
     if (!teachingMission) return { status: 'locked', mission: null };
-    
+
     const isCompleted = completedMissions.includes(teachingMission.id);
     return {
       status: isCompleted ? 'unlocked' : 'locked',
@@ -60,13 +60,13 @@ export default function SkillTree() {
     setSelectedConcept({ concept, mission });
   };
 
-  const renderConceptNode = (concept, categoryIndex, conceptIndex) => {
+  const renderConceptNode = (concept) => {
     const { status, mission } = getConceptStatus(concept);
     const isHovered = hoveredConcept === concept;
     const isSelected = selectedConcept?.concept === concept;
 
     const nodeClass = `concept-node ${status} ${isHovered ? 'hovered' : ''} ${isSelected ? 'selected' : ''}`;
-    
+
     return (
       <div
         key={concept}
@@ -82,46 +82,55 @@ export default function SkillTree() {
         {isHovered && mission && (
           <div className="concept-tooltip">
             <div className="tooltip-mission">{mission.title}</div>
-            <div className="tooltip-chapter">Chapter {mission.chapter}</div>
+            <div className="tooltip-chapter">
+              {t('skillTree.tooltip.chapter', { chapter: mission.chapter })}
+            </div>
           </div>
         )}
       </div>
     );
   };
 
-  const renderCategory = (categoryKey, categoryData, index) => {
+  const renderCategory = (categoryKey, categoryData) => {
     const concepts = categoryData.concepts;
-    const unlockedCount = concepts.filter(concept => 
+    const unlockedCount = concepts.filter(concept =>
       getConceptStatus(concept).status === 'unlocked'
     ).length;
-    const progress = (unlockedCount / concepts.length) * 100;
+    const progressPct = (unlockedCount / concepts.length) * 100;
 
     return (
       <div key={categoryKey} className="skill-category">
         <div className="category-header">
-          <h3 className="category-title">{categoryData.title}</h3>
+          <h3 className="category-title">
+            {t(`skillTree.categories.${categoryKey}.title`)}
+          </h3>
           <div className="category-progress">
             <div className="progress-bar">
-              <div 
-                className="progress-fill" 
-                style={{ width: `${progress}%` }}
+              <div
+                className="progress-fill"
+                style={{ width: `${progressPct}%` }}
               />
             </div>
-            <span className="progress-text">{unlockedCount}/{concepts.length}</span>
+            <span className="progress-text">
+              {t('skillTree.categoryProgress', {
+                unlocked: unlockedCount,
+                total: concepts.length,
+              })}
+            </span>
           </div>
         </div>
-        <p className="category-description">{categoryData.description}</p>
+        <p className="category-description">
+          {t(`skillTree.categories.${categoryKey}.description`)}
+        </p>
         <div className="concept-grid">
-          {concepts.map((concept, conceptIndex) => 
-            renderConceptNode(concept, index, conceptIndex)
-          )}
+          {concepts.map(concept => renderConceptNode(concept))}
         </div>
       </div>
     );
   };
 
   const totalConcepts = Object.values(conceptCategories).reduce((sum, cat) => sum + cat.concepts.length, 0);
-  const totalUnlocked = Object.values(conceptCategories).reduce((sum, cat) => 
+  const totalUnlocked = Object.values(conceptCategories).reduce((sum, cat) =>
     sum + cat.concepts.filter(concept => getConceptStatus(concept).status === 'unlocked').length, 0
   );
   const overallProgress = (totalUnlocked / totalConcepts) * 100;
@@ -129,34 +138,32 @@ export default function SkillTree() {
   return (
     <div className="skill-tree">
       <div className="skill-tree-header">
-        <h1 className="skill-tree-title">Soroban Skill Tree</h1>
-        <p className="skill-tree-subtitle">
-          Track your mastery of Soroban smart contract concepts
-        </p>
+        <h1 className="skill-tree-title">{t('skillTree.title')}</h1>
+        <p className="skill-tree-subtitle">{t('skillTree.subtitle')}</p>
         <div className="overall-progress">
           <div className="progress-bar large">
-            <div 
-              className="progress-fill" 
+            <div
+              className="progress-fill"
               style={{ width: `${overallProgress}%` }}
             />
           </div>
           <span className="progress-text large">
-            {totalUnlocked}/{totalConcepts} Concepts Mastered
+            {t('skillTree.overall', { unlocked: totalUnlocked, total: totalConcepts })}
           </span>
         </div>
       </div>
 
       <div className="skill-categories">
-        {Object.entries(conceptCategories).map(([key, data], index) => 
-          renderCategory(key, data, index)
+        {Object.entries(conceptCategories).map(([key, data]) =>
+          renderCategory(key, data)
         )}
       </div>
 
       {selectedConcept && (
         <div className="concept-detail-modal" onClick={() => setSelectedConcept(null)}>
           <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-            <button 
-              className="modal-close" 
+            <button
+              className="modal-close"
               onClick={() => setSelectedConcept(null)}
             >
               ×
@@ -164,32 +171,35 @@ export default function SkillTree() {
             <h3 className="modal-title">{selectedConcept.concept}</h3>
             {selectedConcept.mission ? (
               <div className="mission-info">
-                <h4>Taught in: {selectedConcept.mission.title}</h4>
-                <p><strong>Chapter:</strong> {selectedConcept.mission.chapter}</p>
-                <p><strong>Difficulty:</strong> {selectedConcept.mission.difficulty}</p>
-                <p><strong>XP Reward:</strong> {selectedConcept.mission.xpReward}</p>
+                <h4>{t('skillTree.modal.taughtIn', { title: selectedConcept.mission.title })}</h4>
+                <p><strong>{t('skillTree.modal.chapterLabel')}</strong> {selectedConcept.mission.chapter}</p>
+                <p>
+                  <strong>{t('skillTree.modal.difficultyLabel')}</strong>{' '}
+                  {t(`difficulty.${selectedConcept.mission.difficulty}`)}
+                </p>
+                <p><strong>{t('skillTree.modal.xpLabel')}</strong> {selectedConcept.mission.xpReward}</p>
                 <div className="mission-learning-goal">
-                  <strong>Learning Goal:</strong>
+                  <strong>{t('skillTree.modal.learningGoal')}</strong>
                   <p>{selectedConcept.mission.learningGoal}</p>
                 </div>
                 <div className="mission-status">
                   {completedMissions.includes(selectedConcept.mission.id) ? (
-                    <span className="status-completed">✅ Completed</span>
+                    <span className="status-completed">{t('skillTree.modal.completed')}</span>
                   ) : (
-                    <span className="status-locked">🔒 Not yet completed</span>
+                    <span className="status-locked">{t('skillTree.modal.notCompleted')}</span>
                   )}
                 </div>
                 {!completedMissions.includes(selectedConcept.mission.id) && (
-                  <a 
+                  <a
                     href={`/mission/${selectedConcept.mission.id}`}
                     className="start-mission-btn"
                   >
-                    Start Mission
+                    {t('skillTree.modal.startMission')}
                   </a>
                 )}
               </div>
             ) : (
-              <p>This concept is not yet covered in available missions.</p>
+              <p>{t('skillTree.modal.notCovered')}</p>
             )}
           </div>
         </div>

--- a/src/systems/missionLoader.js
+++ b/src/systems/missionLoader.js
@@ -1,45 +1,52 @@
 /* ==========================================
    Mission Loader — Fetches and parses mission data
+
+   Phase 3 (i18n): All getters return language-localized mission
+   objects. The language is read from the i18n language bridge, with
+   an optional explicit `lang` override for callers that already know
+   the active language (e.g. a component using useTranslation()).
    ========================================== */
 
-import { missions } from '../data/missions';
+import { missions, localizeMission } from '../data/missions';
+import { getActiveLanguage } from '../i18n/languageBridge';
 
-export function getAllMissions() {
-    return missions;
+export function getAllMissions(lang = getActiveLanguage()) {
+    return missions.map((m) => localizeMission(m, lang));
 }
 
-export function getMissionById(id) {
-    return missions.find(m => m.id === id) || null;
+export function getMissionById(id, lang = getActiveLanguage()) {
+    const mission = missions.find(m => m.id === id);
+    return mission ? localizeMission(mission, lang) : null;
 }
 
-export function getMissionsByChapter() {
+export function getMissionsByChapter(lang = getActiveLanguage()) {
     const chapters = {};
     for (const mission of missions) {
         const ch = mission.chapter || 1;
         if (!chapters[ch]) chapters[ch] = [];
-        chapters[ch].push(mission);
+        chapters[ch].push(localizeMission(mission, lang));
     }
     return chapters;
 }
 
-export function getNextMission(currentId) {
+export function getNextMission(currentId, lang = getActiveLanguage()) {
     const idx = missions.findIndex(m => m.id === currentId);
     if (idx === -1 || idx === missions.length - 1) return null;
-    return missions[idx + 1];
+    return localizeMission(missions[idx + 1], lang);
 }
 
-export function getPreviousMission(currentId) {
+export function getPreviousMission(currentId, lang = getActiveLanguage()) {
     const idx = missions.findIndex(m => m.id === currentId);
     if (idx <= 0) return null;
-    return missions[idx - 1];
+    return localizeMission(missions[idx - 1], lang);
 }
 
 export function isMissionUnlocked(missionId, completedMissions) {
-    const mission = getMissionById(missionId);
-    if (!mission) return false;
+    // Language-neutral: relies only on ids and order.
+    const idx = missions.findIndex(m => m.id === missionId);
+    if (idx === -1) return false;
 
     // First mission is always unlocked
-    const idx = missions.findIndex(m => m.id === missionId);
     if (idx === 0) return true;
 
     // Subsequent missions require the previous one to be completed


### PR DESCRIPTION
## Summary

Implements client-side internationalization with a language selector, adding **English (default)** and **Spanish** support across the entire app. No external i18n libraries — built on React Context. Closes #107.

## What's included

**i18n foundation **
- `LanguageProvider` + Context in `src/i18n/index.jsx`, `useTranslation()` hook exposing `t()`, `language`, `setLanguage`, and the available `languages`.
- `en.json` / `es.json` locale files covering all UI chrome, system messages, toasts, and validation strings.
- Language selector in the Navbar (desktop + mobile), persisted to `localStorage`, defaulting to `navigator.language` on first visit.
- All page components localized via `t('key')`.

**Localized content data**
- Restructured `src/data/missions.js` and `src/data/campaigns.js`: language-neutral fields (`id`, `chapter`, `order`, `difficulty`, `xpReward`, `template`, `solution`, `checks`, `conceptsIntroduced`) stay top-level; localizable fields (`title`, `story`, `learningGoal`, `hints` / `lore`, `description`) moved under per-locale `i18n.en` / `i18n.es` blocks. Full Spanish translations for all 7 missions and 3 campaign chapters.
- Selector helpers `localizeMission` / `localizeMissions` and `localizeCampaign` / `localizeCampaigns` flatten the active locale back onto the object (English fallback, `i18n` block stripped) so consumers keep using `mission.title`, `campaign.lore`, etc.
- New `src/i18n/languageBridge.js` exposes the active language to non-React modules; `missionLoader.js` getters now return localized objects, with an optional `lang` override.
- `LanguageProvider` syncs the bridge synchronously at init and on every change, so first render and live switches both localize correctly.

## How it works

`t('key')` resolves from the active locale with English fallback and `{{var}}` interpolation. Content data is localized at load time through the loader/helpers keyed on the language from `useTranslation()`, with components recomputing via `useMemo`. `isMissionUnlocked` and other id/order logic remain language-neutral.

## Testing

- `npm run build` succeeds.
- `npm test` — all 41 tests pass.
- Manual: all pages load (`/`, `/missions`, `/mission/:id`, `/profile`, campaigns, skill tree); mission validation works; switching EN↔ES updates UI chrome, mission story/hints/learning goals, campaign lore, and skill-tree content live; selection persists across reload.

## Notes

- No new runtime dependencies.
- Adding a third language is just a new `xx.json` + an `i18n.xx` block per mission/campaign (English fallback covers any gaps in the meantime).

