### PR TITLE
Add collaborative mission sync foundation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^9.1.0",
-        "react-router-dom": "^6.28.0"
+        "react-router-dom": "^6.28.0",
+        "y-webrtc": "^10.3.0",
+        "yjs": "^13.6.31"
       },
       "devDependencies": {
         "@playwright/test": "^1.44.0",
@@ -54,7 +56,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1332,7 +1333,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1343,7 +1343,8 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -1509,6 +1510,26 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -1539,7 +1560,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1552,6 +1572,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1715,6 +1759,7 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -1725,6 +1770,12 @@
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/err-code": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
+      "license": "MIT"
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -1864,6 +1915,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-browser-rtc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
+      "integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ==",
+      "license": "MIT"
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -1913,6 +1970,32 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -1976,6 +2059,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2006,6 +2099,27 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/longest-streak": {
@@ -2064,6 +2178,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -2765,7 +2880,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2859,12 +2973,40 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2877,7 +3019,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2953,6 +3094,20 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/remark-parse": {
@@ -3033,6 +3188,26 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -3058,6 +3233,35 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-peer": {
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.11.1.tgz",
+      "integrity": "sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "debug": "^4.3.2",
+        "err-code": "^3.0.1",
+        "get-browser-rtc": "^1.1.0",
+        "queue-microtask": "^1.2.3",
+        "randombytes": "^2.1.0",
+        "readable-stream": "^3.6.0"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -3098,6 +3302,15 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -3313,6 +3526,12 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -3347,7 +3566,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -3512,12 +3730,98 @@
         "node": ">=8"
       }
     },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y-protocols": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
+    "node_modules/y-webrtc": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/y-webrtc/-/y-webrtc-10.3.0.tgz",
+      "integrity": "sha512-KalJr7dCgUgyVFxoG3CQYbpS0O2qybegD0vI4bYnYHI0MOwoVbucED3RZ5f2o1a5HZb1qEssUKS0H/Upc6p1lA==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.42",
+        "simple-peer": "^9.11.0",
+        "y-protocols": "^1.0.6"
+      },
+      "bin": {
+        "y-webrtc-signaling": "bin/server.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "optionalDependencies": {
+        "ws": "^8.14.2"
+      },
+      "peerDependencies": {
+        "yjs": "^13.6.8"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yjs": {
+      "version": "13.6.31",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.31.tgz",
+      "integrity": "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^9.1.0",
-    "react-router-dom": "^6.28.0"
+    "react-router-dom": "^6.28.0",
+    "y-webrtc": "^10.3.0",
+    "yjs": "^13.6.31"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.0",

--- a/src/components/CollaborationAvatar.jsx
+++ b/src/components/CollaborationAvatar.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+export default function CollaborationAvatar({ user, active = false }) {
+  const initial = user?.name?.trim()?.[0]?.toUpperCase() || "?";
+  const style = {
+    "--avatar-color": user?.color || "#06d6a0",
+    alignItems: "center",
+    background: "color-mix(in srgb, var(--avatar-color) 18%, transparent)",
+    border: "1px solid var(--avatar-color)",
+    borderRadius: "999px",
+    boxShadow: active ? "0 0 16px color-mix(in srgb, var(--avatar-color) 42%, transparent)" : "none",
+    color: "var(--text-primary, #f8fafc)",
+    display: "inline-flex",
+    fontSize: "0.72rem",
+    fontWeight: 800,
+    height: "28px",
+    justifyContent: "center",
+    width: "28px",
+  };
+
+  return (
+    <span
+      className={`collaboration-avatar ${active ? "active" : ""}`}
+      title={user?.name || "Collaborator"}
+      aria-label={`${user?.name || "Collaborator"} ${active ? "is editing" : "is connected"}`}
+      style={style}
+    >
+      {initial}
+    </span>
+  );
+}

--- a/src/components/CollaborationBar.jsx
+++ b/src/components/CollaborationBar.jsx
@@ -1,0 +1,179 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Copy, Link2, RefreshCcw, Users } from "lucide-react";
+import CollaborationAvatar from "./CollaborationAvatar";
+import {
+  createCollaborationInvite,
+  createCollaborationManager,
+  readCollaborationRoom,
+} from "../systems/collaboration";
+
+const COLORS = ["#06d6a0", "#8b5cf6", "#f59e0b", "#3b82f6", "#ef4444"];
+const styles = {
+  bar: {
+    alignItems: "center",
+    background: "rgba(17, 24, 39, 0.82)",
+    border: "1px solid rgba(6, 214, 160, 0.24)",
+    borderRadius: "12px",
+    display: "grid",
+    gap: "0.8rem",
+    gridTemplateColumns: "minmax(220px, 1fr) auto minmax(260px, auto)",
+    padding: "0.85rem",
+  },
+  main: {
+    alignItems: "center",
+    display: "flex",
+    gap: "0.7rem",
+  },
+  label: {
+    color: "var(--text-muted, #94a3b8)",
+    fontSize: "0.82rem",
+    margin: 0,
+  },
+  peers: {
+    alignItems: "center",
+    display: "flex",
+    gap: "0.35rem",
+  },
+  actions: {
+    alignItems: "center",
+    display: "flex",
+    flexWrap: "wrap",
+    gap: "0.45rem",
+    justifyContent: "flex-end",
+  },
+  input: {
+    background: "rgba(255, 255, 255, 0.06)",
+    border: "1px solid rgba(255, 255, 255, 0.14)",
+    borderRadius: "8px",
+    color: "var(--text-primary, #f8fafc)",
+    minHeight: "36px",
+    padding: "0 0.65rem",
+    width: "120px",
+  },
+  warning: {
+    color: "var(--gold, #f59e0b)",
+    fontSize: "0.8rem",
+    fontWeight: 700,
+  },
+};
+
+function createLocalUser() {
+  const savedName =
+    typeof localStorage !== "undefined"
+      ? localStorage.getItem("soroban_quest_collab_name")
+      : "";
+  const id =
+    typeof crypto !== "undefined" && crypto.randomUUID
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+  return {
+    id,
+    name: savedName || `Player ${id.slice(0, 4)}`,
+    color: COLORS[Math.floor(Math.random() * COLORS.length)],
+  };
+}
+
+export default function CollaborationBar({
+  missionId,
+  code,
+  onCodeChange,
+  managerFactory = createCollaborationManager,
+}) {
+  const [roomInput, setRoomInput] = useState(() => readCollaborationRoom());
+  const [manager, setManager] = useState(null);
+  const [status, setStatus] = useState({ connected: false, peerCount: 0 });
+  const [peers, setPeers] = useState([]);
+  const [copied, setCopied] = useState(false);
+  const [conflict, setConflict] = useState(false);
+  const user = useMemo(() => createLocalUser(), []);
+
+  useEffect(() => {
+    return () => manager?.destroy();
+  }, [manager]);
+
+  useEffect(() => {
+    if (!manager || code === undefined || code === manager.getCode()) return;
+    manager.setCode(code);
+  }, [code, manager]);
+
+  function startCollaboration(roomId = roomInput) {
+    const nextManager = managerFactory({
+      roomId,
+      missionId,
+      user,
+      initialCode: code,
+    });
+
+    nextManager.on("status", setStatus);
+    nextManager.on("peers", setPeers);
+    nextManager.on("code", (nextCode) => {
+      if (nextCode !== code) onCodeChange?.(nextCode);
+    });
+    nextManager.on("conflict", () => setConflict(true));
+    nextManager.connect();
+
+    manager?.destroy();
+    setManager(nextManager);
+    setStatus(nextManager.getStatus());
+    setPeers(nextManager.getPeers());
+    setRoomInput(nextManager.roomId);
+  }
+
+  async function copyInvite() {
+    const roomId = manager?.roomId || roomInput || undefined;
+    const invite = createCollaborationInvite(roomId);
+    await navigator.clipboard?.writeText(invite);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1800);
+  }
+
+  return (
+    <section className="collaboration-bar" aria-label="Mission collaboration" style={styles.bar}>
+      <div className="collaboration-bar-main" style={styles.main}>
+        <Users size={18} aria-hidden="true" />
+        <div>
+          <strong>Co-op mission</strong>
+          <p style={styles.label}>
+            {status.connected
+              ? `${status.peerCount} collaborator${status.peerCount === 1 ? "" : "s"} connected`
+              : "Invite another player to sync this editor in real time"}
+          </p>
+        </div>
+      </div>
+
+      <div className="collaboration-peers" aria-label="Connected collaborators" style={styles.peers}>
+        <CollaborationAvatar user={user} active />
+        {peers.map((peer) => (
+          <CollaborationAvatar key={peer.id || peer.name} user={peer} active={peer.editing} />
+        ))}
+      </div>
+
+      {conflict && (
+        <span className="collaboration-warning" role="status" style={styles.warning}>
+          Remote edits merged. Review before running tests.
+        </span>
+      )}
+
+      <div className="collaboration-actions" style={styles.actions}>
+        <input
+          value={roomInput}
+          onChange={(event) => setRoomInput(event.target.value)}
+          placeholder="Room code"
+          aria-label="Collaboration room code"
+          style={styles.input}
+        />
+        <button type="button" className="btn-secondary" onClick={() => startCollaboration()}>
+          <Link2 size={16} aria-hidden="true" />
+          {status.connected ? "Reconnect" : "Join"}
+        </button>
+        <button type="button" className="btn-secondary" onClick={copyInvite}>
+          <Copy size={16} aria-hidden="true" />
+          {copied ? "Copied" : "Invite"}
+        </button>
+        <button type="button" className="btn-ghost" onClick={() => manager?.reconnect()}>
+          <RefreshCcw size={16} aria-hidden="true" />
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/systems/__tests__/collaboration.test.js
+++ b/src/systems/__tests__/collaboration.test.js
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CollaborationManager,
+  createCollaborationInvite,
+  readCollaborationRoom,
+} from "../collaboration";
+
+function createProviderMock() {
+  const handlers = new Map();
+  const awarenessStates = new Map();
+  return {
+    connected: false,
+    awareness: {
+      setLocalState: vi.fn(),
+      setLocalStateField: vi.fn((key, value) => {
+        const current = awarenessStates.get("local") || {};
+        awarenessStates.set("local", { ...current, [key]: value });
+      }),
+      getStates: vi.fn(() => awarenessStates),
+      on: vi.fn((event, handler) => handlers.set(`awareness:${event}`, handler)),
+    },
+    on: vi.fn((event, handler) => handlers.set(event, handler)),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    destroy: vi.fn(),
+    emitStatus(status) {
+      handlers.get("status")?.({ status });
+    },
+    addPeer(peer) {
+      awarenessStates.set(peer.id, { user: peer });
+      handlers.get("awareness:change")?.();
+    },
+  };
+}
+
+describe("CollaborationManager", () => {
+  it("syncs local code changes through the shared Yjs document", () => {
+    const provider = createProviderMock();
+    const manager = new CollaborationManager({
+      roomId: "mission-one",
+      missionId: "basics",
+      initialCode: "hello",
+      providerFactory: () => provider,
+    });
+    const onCode = vi.fn();
+
+    manager.on("code", onCode);
+    manager.connect();
+
+    expect(manager.getCode()).toBe("hello");
+    expect(manager.setCode("hello world")).toBe(true);
+    expect(manager.getCode()).toBe("hello world");
+    expect(onCode).toHaveBeenCalledWith("hello world");
+  });
+
+  it("restores a local snapshot so work survives reconnects", () => {
+    const storage = {};
+    vi.stubGlobal("localStorage", {
+      getItem: (key) => storage[key] || null,
+      setItem: (key, value) => {
+        storage[key] = value;
+      },
+    });
+    const first = new CollaborationManager({
+      roomId: "mission-one",
+      missionId: "basics",
+      initialCode: "seed",
+      providerFactory: () => createProviderMock(),
+    });
+
+    first.setCode("saved work");
+    const second = new CollaborationManager({
+      roomId: "mission-one",
+      missionId: "basics",
+      initialCode: "seed",
+      providerFactory: () => createProviderMock(),
+    });
+
+    expect(second.getCode()).toBe("saved work");
+    vi.unstubAllGlobals();
+  });
+
+  it("reports connected peers through awareness updates", () => {
+    const provider = createProviderMock();
+    const manager = new CollaborationManager({
+      roomId: "mission-one",
+      missionId: "basics",
+      providerFactory: () => provider,
+    });
+    const onPeers = vi.fn();
+
+    manager.on("peers", onPeers);
+    manager.connect();
+    provider.addPeer({ id: "peer-1", name: "Ada", color: "#8b5cf6" });
+
+    expect(manager.getPeers()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "peer-1", name: "Ada" }),
+      ]),
+    );
+    expect(onPeers).toHaveBeenCalled();
+  });
+
+  it("emits status updates for disconnect and reconnect flows", () => {
+    const provider = createProviderMock();
+    const manager = new CollaborationManager({
+      roomId: "mission-one",
+      missionId: "basics",
+      providerFactory: () => provider,
+    });
+    const onStatus = vi.fn();
+
+    manager.on("status", onStatus);
+    manager.connect();
+    provider.emitStatus("connected");
+    manager.disconnect();
+    manager.reconnect();
+
+    expect(onStatus).toHaveBeenCalledWith(expect.objectContaining({ connected: true }));
+    expect(provider.disconnect).toHaveBeenCalled();
+    expect(provider.connect).toHaveBeenCalled();
+  });
+
+  it("flags conflicts when remote code arrives after local divergence", () => {
+    const provider = createProviderMock();
+    const manager = new CollaborationManager({
+      roomId: "mission-one",
+      missionId: "basics",
+      initialCode: "base",
+      providerFactory: () => provider,
+    });
+    const onConflict = vi.fn();
+
+    manager.on("conflict", onConflict);
+    manager.connect();
+    manager.lastSyncedCode = "base";
+    manager.code.insert(4, "-local");
+
+    const result = manager.mergeCode("base-remote");
+
+    expect(result.conflict).toBe(true);
+    expect(manager.getCode()).toBe("base-remote");
+    expect(onConflict).toHaveBeenCalledWith(expect.objectContaining({ conflict: true }));
+  });
+});
+
+describe("collaboration invite helpers", () => {
+  it("creates and reads stable room links", () => {
+    const location = { href: "https://quest.example/#/mission/one?foo=bar" };
+    const invite = createCollaborationInvite("room one!", location);
+
+    expect(invite).toContain("collab=room-one-");
+    expect(readCollaborationRoom({ href: invite })).toBe("room-one-");
+  });
+});

--- a/src/systems/collaboration.js
+++ b/src/systems/collaboration.js
@@ -1,0 +1,226 @@
+import * as Y from "yjs";
+import { WebrtcProvider } from "y-webrtc";
+
+const DEFAULT_SIGNALING = [
+  "wss://signaling.yjs.dev",
+  "wss://y-webrtc-signaling-eu.herokuapp.com",
+  "wss://y-webrtc-signaling-us.herokuapp.com",
+];
+
+function createId(prefix = "collab") {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function normalizeRoomId(roomId) {
+  return String(roomId || "")
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]/g, "-")
+    .slice(0, 96);
+}
+
+function getWindowLocation() {
+  if (typeof window === "undefined") return null;
+  return window.location;
+}
+
+function snapshotKey(missionId, roomId) {
+  return `soroban_quest_collab:${missionId}:${roomId}`;
+}
+
+function readSnapshot(missionId, roomId) {
+  try {
+    if (typeof localStorage === "undefined") return "";
+    return localStorage.getItem(snapshotKey(missionId, roomId)) || "";
+  } catch {
+    return "";
+  }
+}
+
+function writeSnapshot(missionId, roomId, code) {
+  try {
+    if (typeof localStorage === "undefined") return;
+    localStorage.setItem(snapshotKey(missionId, roomId), code);
+  } catch {
+    // Storage may be unavailable in private contexts; Yjs still keeps in-memory state.
+  }
+}
+
+export function createCollaborationInvite(roomId, location = getWindowLocation()) {
+  const safeRoomId = normalizeRoomId(roomId);
+  if (!location) return `?collab=${safeRoomId}`;
+
+  const url = new URL(location.href);
+  url.searchParams.set("collab", safeRoomId);
+  return url.toString();
+}
+
+export function readCollaborationRoom(location = getWindowLocation()) {
+  if (!location) return "";
+  return normalizeRoomId(new URL(location.href).searchParams.get("collab"));
+}
+
+export class CollaborationManager {
+  constructor({
+    roomId,
+    missionId,
+    user = {},
+    initialCode = "",
+    providerFactory,
+    awarenessFactory,
+    signaling = DEFAULT_SIGNALING,
+  } = {}) {
+    this.roomId = normalizeRoomId(roomId || createId("mission"));
+    this.missionId = missionId || "mission";
+    this.user = {
+      id: user.id || createId("player"),
+      name: user.name || "Player",
+      color: user.color || "#06d6a0",
+    };
+    this.signaling = signaling;
+    this.providerFactory = providerFactory;
+    this.awarenessFactory = awarenessFactory;
+    this.doc = new Y.Doc();
+    this.code = this.doc.getText("code");
+    this.meta = this.doc.getMap("meta");
+    this.provider = null;
+    this.awareness = null;
+    this.connected = false;
+    this.destroyed = false;
+    const seedCode = readSnapshot(this.missionId, this.roomId) || initialCode;
+    this.lastSyncedCode = seedCode;
+    this.listeners = {
+      code: new Set(),
+      status: new Set(),
+      peers: new Set(),
+      conflict: new Set(),
+    };
+
+    if (seedCode) {
+      this.code.insert(0, seedCode);
+    }
+
+    this.code.observe(() => {
+      const nextCode = this.getCode();
+      writeSnapshot(this.missionId, this.roomId, nextCode);
+      this.emit("code", nextCode);
+    });
+  }
+
+  connect() {
+    if (this.destroyed) {
+      throw new Error("CollaborationManager has been destroyed");
+    }
+    if (this.provider) return this;
+
+    const roomName = `soroban-quest:${this.missionId}:${this.roomId}`;
+    this.provider = this.providerFactory
+      ? this.providerFactory(roomName, this.doc, { signaling: this.signaling })
+      : new WebrtcProvider(roomName, this.doc, { signaling: this.signaling });
+    this.awareness = this.provider.awareness || this.awarenessFactory?.();
+
+    this.provider.on?.("status", (event) => {
+      this.connected = event.status === "connected";
+      this.emit("status", this.getStatus());
+    });
+
+    this.awareness?.setLocalStateField?.("user", this.user);
+    this.awareness?.setLocalStateField?.("editing", {
+      missionId: this.missionId,
+      at: Date.now(),
+    });
+    this.awareness?.on?.("change", () => this.emit("peers", this.getPeers()));
+    this.emit("status", this.getStatus());
+    this.emit("peers", this.getPeers());
+
+    return this;
+  }
+
+  disconnect() {
+    this.connected = false;
+    this.awareness?.setLocalState?.(null);
+    this.provider?.disconnect?.();
+    this.emit("status", this.getStatus());
+    return this;
+  }
+
+  reconnect() {
+    if (!this.provider) return this.connect();
+    this.provider.connect?.();
+    this.emit("status", { ...this.getStatus(), reconnecting: true });
+    return this;
+  }
+
+  destroy() {
+    this.destroyed = true;
+    this.connected = false;
+    this.awareness?.setLocalState?.(null);
+    this.provider?.destroy?.();
+    this.doc.destroy();
+    Object.values(this.listeners).forEach((listeners) => listeners.clear());
+  }
+
+  setCode(nextCode, origin = "local") {
+    const value = String(nextCode ?? "");
+    const current = this.getCode();
+    if (current === value) return false;
+
+    this.doc.transact(() => {
+      this.code.delete(0, this.code.length);
+      this.code.insert(0, value);
+      this.meta.set("updatedBy", this.user.id);
+      this.meta.set("updatedAt", Date.now());
+    }, origin);
+    return true;
+  }
+
+  mergeCode(remoteCode) {
+    const current = this.getCode();
+    const incoming = String(remoteCode ?? "");
+    if (incoming === current) return { changed: false, conflict: false, code: current };
+
+    const localChanged = current !== this.lastSyncedCode;
+    const remoteChanged = incoming !== this.lastSyncedCode;
+    const conflict = localChanged && remoteChanged;
+
+    this.setCode(incoming, "remote");
+    this.lastSyncedCode = incoming;
+    const result = { changed: true, conflict, code: incoming };
+    if (conflict) this.emit("conflict", result);
+    return result;
+  }
+
+  getCode() {
+    return this.code.toString();
+  }
+
+  getStatus() {
+    return {
+      roomId: this.roomId,
+      connected: this.connected,
+      peerCount: this.getPeers().length,
+    };
+  }
+
+  getPeers() {
+    if (!this.awareness?.getStates) return [];
+    return Array.from(this.awareness.getStates().values())
+      .map((state) => state.user)
+      .filter(Boolean);
+  }
+
+  on(type, listener) {
+    this.listeners[type]?.add(listener);
+    return () => this.listeners[type]?.delete(listener);
+  }
+
+  emit(type, payload) {
+    this.listeners[type]?.forEach((listener) => listener(payload));
+  }
+}
+
+export function createCollaborationManager(options) {
+  return new CollaborationManager(options);
+}


### PR DESCRIPTION
Closes #176

## What changed
- Added `src/systems/collaboration.js` with a Yjs/WebRTC-backed `CollaborationManager` for room setup, status events, peer awareness, reconnects, invite links, local snapshots, and conflict signaling.
- Added `CollaborationBar.jsx` for joining/reconnecting/copying invite links and showing connected collaborators.
- Added `CollaborationAvatar.jsx` as a compact connected/editing indicator.
- Added unit tests for code sync, peer awareness, reconnect status, local snapshot recovery, conflict detection, and invite helpers.
- Added `yjs` and `y-webrtc` dependencies.

## Scope note
The issue requested an autonomous implementation in new collaboration files without modifying existing mission components. This PR adds the reusable collaboration system and UI components without wiring them into `MissionDetail.jsx`, so maintainers can integrate the bar where they want in the editor layout.

## Verification
- `npm test -- src/systems/__tests__/collaboration.test.js` passed: 6/6 tests.
- `npm test` passed: 58/58 tests.
- `npm run build` passed.
- `git diff --check` passed.

## Notes
- `npm install` reported existing dependency audit findings after adding Yjs/WebRTC packages: 10 vulnerabilities total. I did not run `npm audit fix` because that would create unrelated dependency churn.