### PR TITLE
test: add e2e tests for campaigns and skilltree pages

### DIFF
--- a/e2e/campaigns.spec.ts
+++ b/e2e/campaigns.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import { clearLocalStorageBeforePageLoad } from './utils';
+
+test.describe('Campaigns Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearLocalStorageBeforePageLoad(page);
+    await page.goto('/');
+  });
+
+  test('is reachable from navbar and renders campaign cards', async ({ page }) => {
+    await page.click('nav >> text=Campaigns');
+
+    await expect(page).toHaveURL(/#\/campaigns/);
+    await expect(page.locator('h1.section-title')).toHaveText('Campaigns');
+    await expect(page.locator('.campaign-card')).toHaveCount(3);
+  });
+
+  test('opens lore modal on first visit and campaign details are visible', async ({ page }) => {
+    await page.goto('/#/campaigns');
+
+    const firstUnlockedCampaign = page.locator('.campaign-card:not(.locked)').first();
+    await firstUnlockedCampaign.click();
+
+    await expect(page.locator('[role="dialog"]')).toBeVisible();
+    await expect(page.locator('#lore-modal-title')).toHaveText('Chapter Introduction');
+    await expect(page.locator('.modal-content .btn.btn-primary')).toContainText('Begin Chapter 1');
+    await expect(page.locator('.campaign-detail-overlay')).toBeVisible();
+    await expect(page.locator('.missions-list .mission-item')).toHaveCount(2);
+  });
+
+  test('lore modal is shown only once per campaign', async ({ page }) => {
+    await page.goto('/#/campaigns');
+
+    const firstUnlockedCampaign = page.locator('.campaign-card:not(.locked)').first();
+    await firstUnlockedCampaign.click();
+    await expect(page.locator('[role="dialog"]')).toBeVisible();
+
+    await page.goto('/#/missions');
+    await page.goto('/#/campaigns');
+
+    const firstUnlockedCampaignAgain = page.locator('.campaign-card:not(.locked)').first();
+    await firstUnlockedCampaignAgain.click();
+
+    await expect(page.locator('[role="dialog"]')).toHaveCount(0);
+    await expect(page.locator('.campaign-detail-overlay')).toBeVisible();
+  });
+});

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -38,8 +38,8 @@ test.describe('Navigation', () => {
   });
 
   test('skill tree page loads and displays skills', async ({ page }) => {
-    await page.goto('/#/skill-tree');
-    await expect(page).toHaveURL(/#\/skill-tree/);
+    await page.goto('/#/skills');
+    await expect(page).toHaveURL(/#\/skills/);
     await expect(page.locator('h1').first()).toBeVisible();
   });
 });

--- a/e2e/skilltree.spec.ts
+++ b/e2e/skilltree.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { clearLocalStorageBeforePageLoad } from './utils';
+
+test.describe('SkillTree Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearLocalStorageBeforePageLoad(page);
+  });
+
+  test('is reachable by route and renders skill categories', async ({ page }) => {
+    await page.goto('/#/skills');
+
+    await expect(page).toHaveURL(/#\/skills/);
+    await expect(page.locator('.skill-tree-title')).toHaveText('Soroban Skill Tree');
+    await expect(page.locator('.skill-category')).toHaveCount(5);
+    await expect(page.locator('.concept-node')).toHaveCount(31);
+  });
+
+  test('renders locked visualization for initial progress', async ({ page }) => {
+    await page.goto('/#/skills');
+
+    const lockedNodes = page.locator('.concept-node.locked');
+    await expect(lockedNodes.first()).toBeVisible();
+    await expect(lockedNodes).toHaveCount(31);
+    await expect(page.locator('.concept-node.unlocked')).toHaveCount(0);
+  });
+
+  test('opens concept modal with mission details', async ({ page }) => {
+    await page.goto('/#/skills');
+
+    await page
+      .locator('.concept-node .concept-name')
+      .filter({ hasText: /^contract$/ })
+      .click();
+
+    await expect(page.locator('.concept-detail-modal')).toBeVisible();
+    await expect(page.locator('.modal-title')).toHaveText('contract');
+    await expect(page.locator('.mission-info')).toBeVisible();
+    await expect(page.locator('.start-mission-btn')).toBeVisible();
+    await expect(page.locator('.start-mission-btn')).toHaveAttribute('href', '/mission/hello-soroban');
+  });
+});


### PR DESCRIPTION
## What does this PR do?
Adds dedicated Playwright E2E coverage for the Campaigns and SkillTree routes.

Changes included:
- Added [e2e/campaigns.spec.ts](e2e/campaigns.spec.ts) with coverage for:
  - navigation to Campaigns
  - campaign card rendering
  - lore modal behavior
- Added [e2e/skilltree.spec.ts](e2e/skilltree.spec.ts) with coverage for:
  - navigation to SkillTree
  - category and node visualization
  - concept detail modal behavior
- Updated [e2e/navigation.spec.ts](e2e/navigation.spec.ts#L40) to use the correct SkillTree route path.

## Related issue
Closes #147

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Content (new mission or educational material)
- [ ] Documentation
- [ ] Refactor

## Testing checklist
- [x] `npm run build` passes
- [x] `npm run lint` passes (if available)
- [x] Tested locally in the browser
- [x] All existing pages still work correctly
- [ ] Screenshots attached (if UI change)

Notes:
- No lint script is defined in [package.json](package.json), and CI skips lint when unavailable.
- Full E2E suite passed locally after these changes.

## Screenshots
Not applicable. This PR adds and updates automated tests only, with no UI changes.
