### PR TITLE
feat: add customizable code editor themes

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -271,7 +271,8 @@
       "hint": "💡 Hint",
       "solution": "👁️ Solution",
       "run": "▶ Run Tests",
-      "running": "Running…"
+      "running": "Running…",
+      "themeLabel": "Editor theme"
     },
     "terminal": {
       "title": "Test Output",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -271,7 +271,8 @@
       "hint": "💡 Pista",
       "solution": "👁️ Solución",
       "run": "▶ Ejecutar pruebas",
-      "running": "Ejecutando…"
+      "running": "Ejecutando…",
+      "themeLabel": "Tema del editor"
     },
     "terminal": {
       "title": "Salida de pruebas",

--- a/src/index.css
+++ b/src/index.css
@@ -1452,6 +1452,46 @@ button {
   background: var(--cyan);
 }
 
+.editor-theme-select {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-family: var(--font-code);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.editor-theme-select-label {
+  display: none;
+}
+
+.editor-theme-select-input {
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 0.4rem 0.6rem;
+  font-family: var(--font-code);
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.editor-theme-select-input:hover {
+  color: var(--text-primary);
+  border-color: var(--cyan);
+}
+
+.editor-theme-select-input:focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: 1px;
+}
+
+@media (min-width: 768px) {
+  .editor-theme-select-label {
+    display: inline;
+  }
+}
+
 .editor-wrapper {
   flex: 1;
   overflow: hidden;

--- a/src/pages/MissionDetail.jsx
+++ b/src/pages/MissionDetail.jsx
@@ -16,6 +16,12 @@ import CodeReplayPlayer from "../components/CodeReplayPlayer";
 import CodeRecorder from "../systems/codeRecorder";
 import { useTranslation } from "../i18n/useTranslation";
 import useDocumentTitle from '../systems/useDocumentTitle';
+import {
+  EDITOR_THEMES,
+  registerEditorThemes,
+  loadEditorTheme,
+  saveEditorTheme,
+} from "../systems/editorThemes";
 
 const LIVE_MARKER_OWNER = "soroban-quest-live";
 const MAX_RANK_INDEX = 10;
@@ -43,7 +49,8 @@ export default function MissionDetail() {
 
   const [livePassCount, setLivePassCount] = useState(0);
   const [liveTotalCount, setLiveTotalCount] = useState(0);
-  const [activeTab, setActiveTab] = useState("story"); 
+  const [activeTab, setActiveTab] = useState("story");
+  const [editorTheme, setEditorTheme] = useState(() => loadEditorTheme());
 
   const terminalBodyRef = useRef(null);
   const editorRef = useRef(null);      
@@ -147,6 +154,16 @@ export default function MissionDetail() {
   const handleEditorMount = useCallback((editor, monaco) => {
     editorRef.current = editor;
     monacoRef.current = monaco;
+    // Register custom themes so the stored selection applies on first paint.
+    registerEditorThemes(monaco);
+    monaco.editor.setTheme(editorTheme);
+  }, [editorTheme]);
+
+  const handleThemeChange = useCallback((event) => {
+    const nextTheme = event.target.value;
+    setEditorTheme(nextTheme);
+    saveEditorTheme(nextTheme);
+    monacoRef.current?.editor.setTheme(nextTheme);
   }, []);
 
   function applyMonacoMarkers(markers) {
@@ -454,6 +471,20 @@ export default function MissionDetail() {
               </div>
             </div>
             <div className="mission-editor-toolbar-right">
+              <label className="editor-theme-select" aria-label={t("missionDetail.editor.themeLabel")}>
+                <span className="editor-theme-select-label">{t("missionDetail.editor.themeLabel")}</span>
+                <select
+                  className="editor-theme-select-input"
+                  value={editorTheme}
+                  onChange={handleThemeChange}
+                >
+                  {EDITOR_THEMES.map((theme) => (
+                    <option key={theme.id} value={theme.id}>
+                      {theme.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
               <button
                 type="button"
                 className="btn btn-ghost btn-sm"
@@ -497,7 +528,7 @@ export default function MissionDetail() {
               defaultLanguage="rust"
               value={code}
               onChange={(v) => setCode(v || "")}
-              theme="vs-dark"
+              theme={editorTheme}
               onMount={handleEditorMount}
               options={{
                 fontSize: 14,

--- a/src/systems/__tests__/editorThemes.test.js
+++ b/src/systems/__tests__/editorThemes.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  EDITOR_THEMES,
+  DEFAULT_THEME_ID,
+  getThemeById,
+  isValidThemeId,
+  registerEditorThemes,
+  loadEditorTheme,
+  saveEditorTheme,
+} from "../editorThemes.js";
+
+describe("editorThemes", () => {
+  let storage;
+
+  beforeEach(() => {
+    storage = {};
+    vi.stubGlobal("localStorage", {
+      getItem: (key) => storage[key] ?? null,
+      setItem: (key, value) => {
+        storage[key] = String(value);
+      },
+      removeItem: (key) => {
+        delete storage[key];
+      },
+    });
+  });
+
+  describe("definitions", () => {
+    it("defines between 3 and 5 themes with unique ids", () => {
+      expect(EDITOR_THEMES.length).toBeGreaterThanOrEqual(3);
+      expect(EDITOR_THEMES.length).toBeLessThanOrEqual(5);
+      const ids = EDITOR_THEMES.map((theme) => theme.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it("ships theme data for every custom (non-builtin) theme", () => {
+      for (const theme of EDITOR_THEMES) {
+        if (!theme.builtin) {
+          expect(theme.data).toBeTruthy();
+          expect(theme.data.base).toBeTruthy();
+        }
+      }
+    });
+
+    it("uses a known id as the default", () => {
+      expect(isValidThemeId(DEFAULT_THEME_ID)).toBe(true);
+    });
+  });
+
+  describe("isValidThemeId / getThemeById", () => {
+    it("accepts known ids and rejects unknown ones", () => {
+      expect(isValidThemeId("vs-dark")).toBe(true);
+      expect(isValidThemeId("not-a-theme")).toBe(false);
+      expect(getThemeById("vs-dark")?.id).toBe("vs-dark");
+      expect(getThemeById("not-a-theme")).toBeUndefined();
+    });
+  });
+
+  describe("persistence", () => {
+    it("returns the default when nothing is stored", () => {
+      expect(loadEditorTheme()).toBe(DEFAULT_THEME_ID);
+    });
+
+    it("persists and reloads a valid theme", () => {
+      saveEditorTheme("soroban-night");
+      expect(storage["soroban_quest_editor_theme"]).toBe("soroban-night");
+      expect(loadEditorTheme()).toBe("soroban-night");
+    });
+
+    it("ignores invalid ids on save", () => {
+      saveEditorTheme("bogus-theme");
+      expect(storage["soroban_quest_editor_theme"]).toBeUndefined();
+    });
+
+    it("falls back to the default when a stored value is invalid", () => {
+      storage["soroban_quest_editor_theme"] = "bogus-theme";
+      expect(loadEditorTheme()).toBe(DEFAULT_THEME_ID);
+    });
+  });
+
+  describe("registerEditorThemes", () => {
+    it("defines every custom theme on the monaco instance", () => {
+      const defineTheme = vi.fn();
+      registerEditorThemes({ editor: { defineTheme } });
+
+      const customThemes = EDITOR_THEMES.filter((theme) => !theme.builtin);
+      expect(defineTheme).toHaveBeenCalledTimes(customThemes.length);
+      for (const theme of customThemes) {
+        expect(defineTheme).toHaveBeenCalledWith(theme.id, theme.data);
+      }
+    });
+
+    it("does nothing when given an unusable monaco instance", () => {
+      expect(() => registerEditorThemes(null)).not.toThrow();
+      expect(() => registerEditorThemes({})).not.toThrow();
+    });
+  });
+});

--- a/src/systems/editorThemes.js
+++ b/src/systems/editorThemes.js
@@ -1,0 +1,124 @@
+/* =========================
+   EDITOR THEMES
+   Color schemes for the Monaco code editor used in missions.
+   Built-in themes ("vs-dark", etc.) are used as-is; custom themes are
+   registered with monaco.editor.defineTheme on editor mount.
+========================= */
+
+const THEME_KEY = "soroban_quest_editor_theme";
+
+/**
+ * Available editor themes.
+ * - `id`: stable identifier persisted in localStorage and passed to Monaco.
+ * - `label`: human-readable name shown in the selector.
+ * - `builtin`: true for Monaco's bundled themes (no definition needed).
+ * - `data`: monaco theme definition, required for custom themes.
+ */
+export const EDITOR_THEMES = [
+  {
+    id: "vs-dark",
+    label: "Dark (default)",
+    builtin: true,
+  },
+  {
+    id: "vs",
+    label: "Light",
+    builtin: true,
+  },
+  {
+    id: "hc-black",
+    label: "High Contrast",
+    builtin: true,
+  },
+  {
+    id: "soroban-night",
+    label: "Soroban Night",
+    builtin: false,
+    data: {
+      base: "vs-dark",
+      inherit: true,
+      rules: [
+        { token: "comment", foreground: "5c6370", fontStyle: "italic" },
+        { token: "keyword", foreground: "56b6c2" },
+        { token: "string", foreground: "98c379" },
+        { token: "number", foreground: "d19a66" },
+        { token: "type", foreground: "e5c07b" },
+      ],
+      colors: {
+        "editor.background": "#0d1117",
+        "editor.foreground": "#c9d1d9",
+        "editor.lineHighlightBackground": "#161b22",
+        "editorLineNumber.foreground": "#484f58",
+        "editorCursor.foreground": "#58a6ff",
+      },
+    },
+  },
+  {
+    id: "stellar-dawn",
+    label: "Stellar Dawn",
+    builtin: false,
+    data: {
+      base: "vs",
+      inherit: true,
+      rules: [
+        { token: "comment", foreground: "a0a1a7", fontStyle: "italic" },
+        { token: "keyword", foreground: "a626a4" },
+        { token: "string", foreground: "50a14f" },
+        { token: "number", foreground: "986801" },
+        { token: "type", foreground: "c18401" },
+      ],
+      colors: {
+        "editor.background": "#fafafa",
+        "editor.foreground": "#383a42",
+        "editor.lineHighlightBackground": "#f0f0f1",
+        "editorLineNumber.foreground": "#9d9d9f",
+        "editorCursor.foreground": "#526fff",
+      },
+    },
+  },
+];
+
+export const DEFAULT_THEME_ID = "vs-dark";
+
+/** Returns the theme definition for an id, or undefined when unknown. */
+export function getThemeById(id) {
+  return EDITOR_THEMES.find((theme) => theme.id === id);
+}
+
+/** Returns true when `id` matches a known theme. */
+export function isValidThemeId(id) {
+  return EDITOR_THEMES.some((theme) => theme.id === id);
+}
+
+/**
+ * Register every custom theme with the given monaco instance. Built-in themes
+ * are skipped since Monaco already knows them. Safe to call more than once.
+ */
+export function registerEditorThemes(monaco) {
+  if (!monaco?.editor?.defineTheme) return;
+  for (const theme of EDITOR_THEMES) {
+    if (!theme.builtin && theme.data) {
+      monaco.editor.defineTheme(theme.id, theme.data);
+    }
+  }
+}
+
+/** Read the persisted theme id, falling back to the default when unset/invalid. */
+export function loadEditorTheme() {
+  try {
+    const stored = localStorage.getItem(THEME_KEY);
+    return stored && isValidThemeId(stored) ? stored : DEFAULT_THEME_ID;
+  } catch {
+    return DEFAULT_THEME_ID;
+  }
+}
+
+/** Persist the selected theme id. Unknown ids are ignored. */
+export function saveEditorTheme(id) {
+  if (!isValidThemeId(id)) return;
+  try {
+    localStorage.setItem(THEME_KEY, id);
+  } catch {
+    /* localStorage may be unavailable (private mode, quota); ignore. */
+  }
+}


### PR DESCRIPTION
Closes #171

## Resumen
Agrega soporte para múltiples temas en el editor de código (Monaco) en las misiones, permitiendo al usuario elegir entre varios esquemas de color. La preferencia se guarda en `localStorage` y persiste entre sesiones.

## Cambios
- **`src/systems/editorThemes.js`** (nuevo) — define 5 temas seleccionables:
  - Built-in de Monaco: **Dark** (por defecto), **Light**, **High Contrast**.
  - Personalizados: **Soroban Night** y **Stellar Dawn** (definidos con `monaco.editor.defineTheme`).
  - Helpers: `registerEditorThemes()`, `loadEditorTheme()`, `saveEditorTheme()`, `getThemeById()`, `isValidThemeId()`. Persistencia en `localStorage` (clave `soroban_quest_editor_theme`) con fallback seguro al tema por defecto si el valor guardado falta o es inválido.
- **`src/pages/MissionDetail.jsx`** — selector de tema en la barra de herramientas del editor; el tema del `<Editor>` se controla por estado y los temas personalizados se registran en el `onMount`.
- **`src/index.css`** — estilos del selector (consistentes con la barra existente; etiqueta visible en pantallas ≥768px).
- **i18n** — nuevas cadenas `missionDetail.editor.themeLabel` en `en.json` y `es.json`.
- **`src/systems/__tests__/editorThemes.test.js`** (nuevo) — pruebas de definiciones, validación, persistencia y registro.

## Tareas
- [x] Definir 3-5 temas de editor (5 definidos)
- [x] Integrar selector de tema en la UI
- [x] Persistir preferencia en localStorage

## Criterios de aceptación
- [x] El usuario puede cambiar el tema del editor
- [x] La preferencia persiste entre sesiones
- [x] Los temas se ven correctamente

## Pruebas
- `npm test` → 62 pruebas pasan (incluye 10 nuevas en `editorThemes.test.js`).
- `npm run build` → compila correctamente.