### PR TITLE
feat: overhaul journal filtering and virtualization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
+        "@tanstack/react-virtual": "^3.14.3",
         "lucide-react": "^1.8.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -54,7 +55,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1210,6 +1210,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.3.tgz",
+      "integrity": "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
+      "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1332,7 +1359,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1343,7 +1369,8 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -1539,7 +1566,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1715,6 +1741,7 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -2064,6 +2091,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -2765,7 +2793,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2864,7 +2891,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2877,7 +2903,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3347,7 +3372,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",
+    "@tanstack/react-virtual": "^3.14.3",
     "lucide-react": "^1.8.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -166,6 +166,11 @@
     "subtitle": "Your journey through the Soroban realm, recorded for eternity.",
     "clearLog": "🗑️ Clear Log",
     "confirmClear": "Clear all activity history?",
+    "controlsLabel": "Journal search and filters",
+    "searchLabel": "Search journal entries",
+    "searchPlaceholder": "Search journal entries...",
+    "typeFilterLabel": "Filter by activity type",
+    "dateFilterLabel": "Filter by date",
     "summary": {
       "missions": "Missions",
       "badges": "Badges",
@@ -180,6 +185,12 @@
       "levelUp": "Level Up",
       "hint": "Hint",
       "system": "System"
+    },
+    "dateFilters": {
+      "all": "Any time",
+      "today": "Today",
+      "week": "Last 7 days",
+      "month": "This month"
     },
     "empty": "No activities recorded yet. Start your first mission!",
     "dates": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -166,6 +166,11 @@
     "subtitle": "Tu viaje a través del reino de Soroban, registrado para la eternidad.",
     "clearLog": "🗑️ Borrar registro",
     "confirmClear": "¿Borrar todo el historial de actividad?",
+    "controlsLabel": "Búsqueda y filtros del diario",
+    "searchLabel": "Buscar entradas del diario",
+    "searchPlaceholder": "Buscar entradas del diario...",
+    "typeFilterLabel": "Filtrar por tipo de actividad",
+    "dateFilterLabel": "Filtrar por fecha",
     "summary": {
       "missions": "Misiones",
       "badges": "Insignias",
@@ -180,6 +185,12 @@
       "levelUp": "Subida de nivel",
       "hint": "Pista",
       "system": "Sistema"
+    },
+    "dateFilters": {
+      "all": "Cualquier fecha",
+      "today": "Hoy",
+      "week": "Últimos 7 días",
+      "month": "Este mes"
     },
     "empty": "Aún no hay actividades registradas. ¡Comienza tu primera misión!",
     "dates": {

--- a/src/pages/Journal.css
+++ b/src/pages/Journal.css
@@ -3,9 +3,17 @@
    ========================================== */
 
 .journal-page {
+  background: #0a0e1a;
+  box-shadow: 0 0 0 100vmax #0a0e1a;
+  clip-path: inset(0 -100vmax);
   max-width: 900px;
   margin: 0 auto;
   padding: var(--space-xl) var(--space-md);
+}
+
+[data-theme="light"] .journal-page {
+  background: #fdfbf7;
+  box-shadow: 0 0 0 100vmax #fdfbf7;
 }
 
 .journal-header {
@@ -60,10 +68,34 @@
 }
 
 /* Filters */
+.journal-controls {
+  display: grid;
+  gap: var(--space-md);
+  margin-bottom: var(--space-lg);
+}
+
+.journal-search input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-md);
+  background: var(--bg-glass);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  font-size: 0.95rem;
+}
+
+.journal-search input:focus {
+  outline: 2px solid var(--cyan-dim);
+  border-color: var(--cyan);
+}
+
+.journal-search input::placeholder {
+  color: var(--text-muted);
+}
+
 .journal-filters {
   display: flex;
   gap: 0.5rem;
-  margin-bottom: var(--space-lg);
   flex-wrap: wrap;
 }
 
@@ -109,8 +141,25 @@
   opacity: 0.3;
 }
 
-.date-group {
-  margin-bottom: var(--space-xl);
+.timeline-viewport {
+  background: #0a0e1a;
+  border-radius: var(--radius-md);
+  height: min(70vh, 720px);
+  overflow: auto;
+  padding-right: 0.5rem;
+  position: relative;
+  scroll-behavior: smooth;
+}
+
+[data-theme="light"] .timeline-viewport {
+  background: #fdfbf7;
+}
+
+.timeline-row {
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
 }
 
 .date-header {
@@ -135,7 +184,7 @@
 
 .timeline-event {
   position: relative;
-  padding-bottom: var(--space-xl);
+  padding-bottom: var(--space-md);
 }
 
 .event-dot {

--- a/src/pages/Journal.jsx
+++ b/src/pages/Journal.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useMemo } from "react";
+import React, { useMemo, useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   getActivityLog,
   ACTIVITY_TYPES,
@@ -17,6 +18,13 @@ const FILTER_DEFS = [
   { id: "LEVEL_UP", labelKey: "journal.filters.levelUp", bucket: "levelUp" },
   { id: "HINT", labelKey: "journal.filters.hint", bucket: "hint" },
   { id: "SYSTEM", labelKey: "journal.filters.system", bucket: "system" },
+];
+
+const DATE_FILTERS = [
+  { id: "ALL", labelKey: "journal.dateFilters.all" },
+  { id: "TODAY", labelKey: "journal.dateFilters.today" },
+  { id: "WEEK", labelKey: "journal.dateFilters.week" },
+  { id: "MONTH", labelKey: "journal.dateFilters.month" },
 ];
 
 // Map each activity type to a visual bucket (icon + class + label key).
@@ -81,34 +89,95 @@ function formatEventMessage(entry, t) {
   }
 }
 
+export function getEntryBucket(entry) {
+  return EVENT_CONFIG[entry.type]?.bucket || "system";
+}
+
+export function filterJournalEntries(entries, { typeFilter = "ALL", dateFilter = "ALL", searchTerm = "" } = {}, t = (key) => key) {
+  const normalizedSearch = searchTerm.trim().toLowerCase();
+  const targetBucket = FILTER_DEFS.find((f) => f.id === typeFilter)?.bucket;
+
+  return entries.filter((entry) => {
+    if (targetBucket && getEntryBucket(entry) !== targetBucket) return false;
+    if (!matchesDateFilter(entry.timestamp, dateFilter)) return false;
+
+    if (!normalizedSearch) return true;
+
+    const message = formatEventMessage(entry, t);
+    const dataText = entry.data ? JSON.stringify(entry.data) : "";
+    return `${message} ${dataText}`.toLowerCase().includes(normalizedSearch);
+  });
+}
+
+export function buildJournalRows(entries, t, language) {
+  const rows = [];
+  let currentDate = null;
+
+  for (const entry of entries) {
+    const date = new Date(entry.timestamp);
+    const dateLabel = formatDateHeader(date, t, language);
+    if (dateLabel !== currentDate) {
+      currentDate = dateLabel;
+      rows.push({ type: "date", id: `date-${dateLabel}`, date: dateLabel });
+    }
+    rows.push({ type: "entry", id: entry.id, entry });
+  }
+
+  return rows;
+}
+
+function matchesDateFilter(timestamp, filter) {
+  if (filter === "ALL") return true;
+
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return false;
+
+  const now = new Date();
+  const start = new Date(now);
+  start.setHours(0, 0, 0, 0);
+
+  if (filter === "TODAY") {
+    return date >= start;
+  }
+
+  if (filter === "WEEK") {
+    start.setDate(start.getDate() - 6);
+    return date >= start;
+  }
+
+  if (filter === "MONTH") {
+    start.setDate(1);
+    return date >= start;
+  }
+
+  return true;
+}
+
 export default function Journal() {
   const { t, language } = useTranslation();
   useDocumentTitle('Journal');
   const [log, setLog] = useState(() => getActivityLog());
   const [filter, setFilter] = useState("ALL");
+  const [dateFilter, setDateFilter] = useState("ALL");
+  const [searchTerm, setSearchTerm] = useState("");
+  const timelineRef = useRef(null);
   const progress = loadProgress();
 
   const filteredLog = useMemo(() => {
-    if (filter === "ALL") return log;
-    const targetBucket = FILTER_DEFS.find((f) => f.id === filter)?.bucket;
-    if (!targetBucket) return log;
-    return log.filter((entry) => {
-      const cfg = EVENT_CONFIG[entry.type];
-      return cfg?.bucket === targetBucket;
-    });
-  }, [log, filter]);
+    return filterJournalEntries(log, { typeFilter: filter, dateFilter, searchTerm }, t);
+  }, [log, filter, dateFilter, searchTerm, t]);
 
-  // Group by date — formatted using current locale.
-  const groupedLog = useMemo(() => {
-    const groups = {};
-    filteredLog.forEach((entry) => {
-      const date = new Date(entry.timestamp);
-      const dateStr = formatDateHeader(date, t, language);
-      if (!groups[dateStr]) groups[dateStr] = [];
-      groups[dateStr].push(entry);
-    });
-    return groups;
-  }, [filteredLog, t, language]);
+  const timelineRows = useMemo(
+    () => buildJournalRows(filteredLog, t, language),
+    [filteredLog, t, language],
+  );
+
+  const rowVirtualizer = useVirtualizer({
+    count: timelineRows.length,
+    getScrollElement: () => timelineRef.current,
+    estimateSize: (index) => (timelineRows[index]?.type === "date" ? 56 : 132),
+    overscan: 8,
+  });
 
   const handleClear = () => {
     if (window.confirm(t("journal.confirmClear"))) {
@@ -173,20 +242,44 @@ export default function Journal() {
       </div>
 
       {/* Filters */}
-      <div className="journal-filters">
-        {FILTER_DEFS.map((f) => (
-          <button
-            key={f.id}
-            className={`filter-chip ${filter === f.id ? "active" : ""}`}
-            onClick={() => setFilter(f.id)}
-          >
-            {t(f.labelKey)}
-          </button>
-        ))}
+      <div className="journal-controls" aria-label={t("journal.controlsLabel")}>
+        <label className="journal-search">
+          <span className="sr-only">{t("journal.searchLabel")}</span>
+          <input
+            type="search"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            placeholder={t("journal.searchPlaceholder")}
+          />
+        </label>
+
+        <div className="journal-filters" aria-label={t("journal.typeFilterLabel")}>
+          {FILTER_DEFS.map((f) => (
+            <button
+              key={f.id}
+              className={`filter-chip ${filter === f.id ? "active" : ""}`}
+              onClick={() => setFilter(f.id)}
+            >
+              {t(f.labelKey)}
+            </button>
+          ))}
+        </div>
+
+        <div className="journal-filters" aria-label={t("journal.dateFilterLabel")}>
+          {DATE_FILTERS.map((f) => (
+            <button
+              key={f.id}
+              className={`filter-chip ${dateFilter === f.id ? "active" : ""}`}
+              onClick={() => setDateFilter(f.id)}
+            >
+              {t(f.labelKey)}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Timeline */}
-      {Object.keys(groupedLog).length === 0 ? (
+      {timelineRows.length === 0 ? (
         <div className="card text-center p-12">
           <div style={{ fontSize: "3rem", marginBottom: "1rem", opacity: 0.3 }}>
             📖
@@ -194,49 +287,73 @@ export default function Journal() {
           <p className="text-secondary">{t("journal.empty")}</p>
         </div>
       ) : (
-        <div className="timeline">
-          {Object.entries(groupedLog).map(([date, entries]) => (
-            <div key={date} className="date-group">
-              <div className="date-header">{date}</div>
-              {entries.map((entry) => {
-                const config = EVENT_CONFIG[entry.type] || {
-                  icon: "❓",
-                  class: "system",
-                };
-                const time = new Date(entry.timestamp).toLocaleTimeString(
-                  timeLocale,
-                  { hour: "2-digit", minute: "2-digit" },
-                );
-
-                const displayMessage = formatEventMessage(entry, t);
-
-                return (
-                  <div key={entry.id} className="timeline-event">
-                    <div className={`event-dot ${config.class}`}>
-                      {config.icon}
-                    </div>
-                    <div className="event-content">
-                      <div className="event-time">{time}</div>
-                      <div className="event-message">{displayMessage}</div>
-                      {entry.data && Object.keys(entry.data).length > 0 && (
-                        <div className="event-details">
-                          {entry.type === ACTIVITY_TYPES.LEVEL_UP &&
-                            t("journal.details.targetXp", { xp: progress.xp })}
-                          {entry.type === ACTIVITY_TYPES.MISSION_COMPLETED &&
-                            entry.data.xp != null &&
-                            t("journal.details.earnedXp", {
-                              xp: entry.data.xp,
-                            })}
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          ))}
+        <div className="timeline-viewport" ref={timelineRef}>
+          <div
+            className="timeline"
+            style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+          >
+            {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+              const row = timelineRows[virtualRow.index];
+              return (
+                <div
+                  key={row.id}
+                  className="timeline-row"
+                  style={{
+                    height: `${virtualRow.size}px`,
+                    transform: `translateY(${virtualRow.start}px)`,
+                  }}
+                >
+                  {row.type === "date" ? (
+                    <div className="date-header">{row.date}</div>
+                  ) : (
+                    <JournalEntry
+                      entry={row.entry}
+                      progressXp={progress.xp}
+                      timeLocale={timeLocale}
+                      t={t}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
         </div>
       )}
+    </div>
+  );
+}
+
+function JournalEntry({ entry, progressXp, timeLocale, t }) {
+  const config = EVENT_CONFIG[entry.type] || {
+    icon: "❓",
+    class: "system",
+  };
+  const time = new Date(entry.timestamp).toLocaleTimeString(
+    timeLocale,
+    { hour: "2-digit", minute: "2-digit" },
+  );
+  const displayMessage = formatEventMessage(entry, t);
+
+  return (
+    <div className="timeline-event">
+      <div className={`event-dot ${config.class}`}>
+        {config.icon}
+      </div>
+      <div className="event-content">
+        <div className="event-time">{time}</div>
+        <div className="event-message">{displayMessage}</div>
+        {entry.data && Object.keys(entry.data).length > 0 && (
+          <div className="event-details">
+            {entry.type === ACTIVITY_TYPES.LEVEL_UP &&
+              t("journal.details.targetXp", { xp: progressXp })}
+            {entry.type === ACTIVITY_TYPES.MISSION_COMPLETED &&
+              entry.data.xp != null &&
+              t("journal.details.earnedXp", {
+                xp: entry.data.xp,
+              })}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/pages/__tests__/Journal.test.jsx
+++ b/src/pages/__tests__/Journal.test.jsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildJournalRows, filterJournalEntries } from "../Journal.jsx";
+
+const t = (key, vars = {}) => {
+  const messages = {
+    "journal.events.missionStarted": `Started mission: ${vars.title}`,
+    "journal.events.badgeEarned": `Earned ${vars.name}`,
+    "journal.dates.today": "Today",
+    "journal.dates.yesterday": "Yesterday",
+  };
+  return messages[key] || key;
+};
+
+const entries = [
+  {
+    id: "newer",
+    timestamp: "2026-06-25T06:00:00.000Z",
+    type: "MISSION_STARTED",
+    data: { title: "Counter Vault" },
+  },
+  {
+    id: "older",
+    timestamp: "2025-06-25T06:00:00.000Z",
+    type: "BADGE_EARNED",
+    data: { badgeName: "First Contract" },
+  },
+];
+
+describe("Journal helpers", () => {
+  it("filters entries by activity type and search text", () => {
+    const filtered = filterJournalEntries(
+      entries,
+      { typeFilter: "MISSION", searchTerm: "counter" },
+      t,
+    );
+
+    expect(filtered.map((entry) => entry.id)).toEqual(["newer"]);
+  });
+
+  it("filters entries by date range", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-25T12:00:00.000Z"));
+
+    const filtered = filterJournalEntries(entries, { dateFilter: "TODAY" }, t);
+
+    expect(filtered.map((entry) => entry.id)).toEqual(["newer"]);
+    vi.useRealTimers();
+  });
+
+  it("builds date rows using full year comparisons", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-25T12:00:00.000Z"));
+
+    const rows = buildJournalRows(entries, t, "en");
+
+    expect(rows[0]).toMatchObject({ type: "date", date: "Today" });
+    expect(rows[2]).toMatchObject({ type: "date", date: "June 25, 2025" });
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
Closes #165

## What changed
- Added virtualized Journal timeline rendering with `@tanstack/react-virtual` for large activity logs.
- Added text search across translated messages and entry metadata.
- Added date filters for any time, today, last 7 days, and this month.
- Kept the existing type filters and made the filter/search controls localized in English and Spanish.
- Added unit coverage for Journal filtering, date range filtering, and date grouping with full-year comparisons.

## Visual QA
Verified locally at `http://127.0.0.1:5174/#/journal` with 560 seeded activity entries.
- Desktop Journal renders cleanly with the virtualized timeline.
- Search for `Counter Vault 16` shows matching grouped entries.
- Mission + Last 7 days filter narrows to the expected entry.
- Mobile viewport at 390px has no horizontal overflow and controls wrap correctly.

## Verification
- `npm test -- Journal.test.jsx` passes: 3/3 tests.
- `npm test` passes: 55/55 tests.
- `npm run build` passes.