### PR TITLE
feat: implemented automatic scroll-to-top on route navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,9 +9,8 @@ import Journal from "./pages/Journal";
 import Campaigns from "./pages/Campaigns";
 import SkillTree from "./pages/SkillTree";
 import Footer from "./components/Footer";
-import ScrollToTop from "./components/ScrollToTop";
 
-// 1. Import the ErrorBoundary
+import useScrollToTop from "./hooks/useScrollToTop";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { ToastProvider } from "./systems/ToastContext";
 import { GameStateProvider } from "./systems/GameStateContext";
@@ -24,6 +23,9 @@ import "./systems/Toast.css";
 const NotFound = lazy(() => import("./pages/NotFound"));
 
 export default function App() {
+  // Global React Router navigation scroll management
+  useScrollToTop();
+
   useEffect(() => {
     const state = loadProgress();
     const newState = updateStreak(state);

--- a/src/hooks/useScrollToTop.js
+++ b/src/hooks/useScrollToTop.js
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { useLocation, useNavigationType } from "react-router-dom";
+
+export default function useScrollToTop() {
+  const { pathname } = useLocation();
+  const navigationType = useNavigationType();
+
+  useEffect(() => {
+    // Keep standard browser history back/forward placement untouched
+    if (navigationType !== "POP") {
+      
+      // 1. Reset global window layer
+      window.scrollTo({
+        top: 0,
+        left: 0,
+        behavior: "instant"
+      });
+
+      // 2. Reset internal DOM main layout wrappers if they hold the overflow scrollbars
+      const scrollContainers = document.querySelectorAll(".main-content, .app, main");
+      scrollContainers.forEach((container) => {
+        container.scrollTop = 0;
+      });
+    }
+  }, [pathname, navigationType]);
+}


### PR DESCRIPTION
Closes #166

What does this PR do:
This PR introduces the custom hook to automatically reset scroll positions upon navigating between different routes, fixing a common SPA layout issue where scroll positions are improperly retained across page changes.useScrollToTop.

Key updates include:

[x] Viewport Reset: Automatically targets the global window coordinate plane as well as local overflow containers (, , ) to handle custom flex/grid viewport scroll mechanics seamlessly..main-content.appmain

[x] History Navigation Retention: Inspects the navigation action type to completely skip scroll resets during history triggers (e.g., clicking the browser's Back or Forward buttons), preserving native browser scroll state memory.POP

[x] Cleanup & Optimization: Removes a redundant, conflicting legacy component layout token inside to prevent race conditions and layout double-triggering.<ScrollToTop />App.jsx.

Type of change:
[x] New feature
[x] Refactor

Testing checklist:
[x] Passesnpm run build
[x] Tested locally in the browser
[x] All existing pages still work correctly



