### PR TITLE
feat(campaigns): add skeleton loading, unlockable skills display, and…

### DIFF
--- a/src/pages/Campaigns.css
+++ b/src/pages/Campaigns.css
@@ -26,7 +26,8 @@
   overflow: hidden;
   transition: all var(--transition-slow);
   cursor: pointer;
-  height: 320px;
+  min-height: 380px;
+  height: auto;
   display: flex;
   flex-direction: column;
 }
@@ -272,7 +273,8 @@
   }
 
   .campaign-card {
-    height: 360px;
+    min-height: 400px;
+    height: auto;
   }
 
   .campaign-hero {
@@ -284,4 +286,125 @@
   .campaigns-page {
     padding: var(--space-xl) var(--space-lg);
   }
+}
+
+/* Skills display */
+.campaign-skills {
+  margin-top: var(--space-xs);
+  margin-bottom: var(--space-lg);
+}
+
+.skills-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  display: block;
+  margin-bottom: var(--space-xs);
+}
+
+.skills-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.skill-badge {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  font-size: 0.7rem;
+  padding: 4px var(--space-sm);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono, monospace);
+  font-weight: 500;
+  transition: all var(--transition-base);
+}
+
+.campaign-card:hover .skill-badge {
+  border-color: var(--border-accent);
+  color: var(--cyan);
+}
+
+/* Skeleton Loading styles */
+.skeleton-pulse {
+  background: linear-gradient(
+    90deg,
+    var(--bg-card) 25%,
+    var(--border-subtle) 37%,
+    var(--bg-card) 63%
+  );
+  background-size: 400% 100%;
+  animation: skeleton-loading 1.4s ease infinite;
+}
+
+@keyframes skeleton-loading {
+  0% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0 50%;
+  }
+}
+
+.skeleton-title {
+  height: 2.2rem;
+  width: 280px;
+  margin: 0 auto var(--space-md);
+  border-radius: var(--radius-md);
+}
+
+.skeleton-subtitle {
+  height: 1.2rem;
+  width: 380px;
+  margin: 0 auto;
+  border-radius: var(--radius-md);
+}
+
+.skeleton-card {
+  pointer-events: none;
+}
+
+.skeleton-hero {
+  height: 160px;
+  width: 100%;
+}
+
+.skeleton-line {
+  border-radius: var(--radius-sm);
+  margin-bottom: var(--space-md);
+}
+
+.skeleton-line.skeleton-title {
+  height: 1.6rem;
+  width: 60%;
+}
+
+.skeleton-line.skeleton-desc {
+  height: 1rem;
+  width: 100%;
+  margin-bottom: var(--space-xs);
+}
+
+.skeleton-skills-label {
+  height: 0.8rem;
+  width: 35%;
+  margin-top: var(--space-sm);
+  margin-bottom: var(--space-xs);
+  border-radius: var(--radius-xs);
+}
+
+.skeleton-skills {
+  height: 2rem;
+  width: 80%;
+  margin-bottom: var(--space-lg);
+  border-radius: var(--radius-sm);
+}
+
+.skeleton-progress {
+  height: 1.8rem;
+  width: 100%;
+  border-radius: var(--radius-md);
+  margin-top: auto;
 }

--- a/src/pages/Campaigns.jsx
+++ b/src/pages/Campaigns.jsx
@@ -11,6 +11,7 @@ import { missions, localizeMissions } from "../data/missions.js";
 import { campaigns, localizeCampaigns, getCampaignProgress } from "../data/campaigns.js";
 import { loadProgress } from "../systems/storage.js";
 import { isMissionUnlocked } from "../systems/missionLoader.js";
+import { getLevelFromXP } from "../systems/gameEngine.js";
 import { useTranslation } from "../i18n/useTranslation";
 
 import "./Campaigns.css";
@@ -23,7 +24,7 @@ export default function Campaigns() {
   const [selectedCampaignId, setSelectedCampaignId] = useState(null);
   const [showLoreModal, setShowLoreModal] = useState(false);
   const [firstVisit, setFirstVisit] = useState(false);
-
+  const [loading, setLoading] = useState(true);
 
   const localizedCampaigns = useMemo(
     () => localizeCampaigns(campaigns, language),
@@ -39,6 +40,12 @@ export default function Campaigns() {
   );
   const loreModalRef = useRef(null);
 
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setLoading(false);
+    }, 800);
+    return () => clearTimeout(timer);
+  }, []);
 
   useEffect(() => {
     const handleStorageChange = () => setProgress(loadProgress());
@@ -97,11 +104,34 @@ export default function Campaigns() {
     setFirstVisit(false);
   };
 
-  const getLevelFromXP = (xp) => {
-    return Math.floor(xp / 300) + 1;
-  };
-
   const currentLevel = getLevelFromXP(progress.xp || 0);
+
+  if (loading) {
+    return (
+      <div id="main-content" className="campaigns-page">
+        <div className="page-header">
+          <div className="skeleton-title skeleton-pulse" />
+          <div className="skeleton-subtitle skeleton-pulse" />
+        </div>
+
+        <div className="campaigns-grid">
+          {[1, 2, 3].map((n) => (
+            <div key={n} className="campaign-card skeleton-card">
+              <div className="campaign-hero skeleton-hero skeleton-pulse" />
+              <div className="campaign-info">
+                <div className="skeleton-line skeleton-title skeleton-pulse" />
+                <div className="skeleton-line skeleton-desc skeleton-pulse" />
+                <div className="skeleton-line skeleton-desc skeleton-pulse" style={{ width: "80%" }} />
+                <div className="skeleton-skills-label skeleton-pulse" />
+                <div className="skeleton-skills skeleton-pulse" />
+                <div className="skeleton-progress skeleton-pulse" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div id="main-content" className="campaigns-page">
@@ -124,6 +154,14 @@ export default function Campaigns() {
           );
           const unlocked = currentLevel >= campaign.requiredLevel;
           const completed = stats.completed === stats.total;
+
+          const campaignMissions = campaign.missionIds
+            .map((id) => localizedMissions.find((m) => m.id === id))
+            .filter(Boolean);
+          const unlockableSkills = Array.from(
+            new Set(campaignMissions.flatMap((m) => m.conceptsIntroduced || [])),
+          );
+          const skillsTitle = language === "es" ? "Habilidades a desbloquear:" : "Skills to unlock:";
 
           return (
             <div
@@ -157,6 +195,15 @@ export default function Campaigns() {
               <div className="campaign-info">
                 <h3 className="campaign-title">{campaign.title}</h3>
                 <p className="campaign-desc">{campaign.description}</p>
+
+                <div className="campaign-skills">
+                  <span className="skills-label">{skillsTitle}</span>
+                  <div className="skills-list">
+                    {unlockableSkills.map((skill) => (
+                      <span key={skill} className="skill-badge">{skill}</span>
+                    ))}
+                  </div>
+                </div>
 
                 <div className="campaign-progress" aria-label={`Chapter progress: ${stats.percentage}% complete`}>
                   <div className="progress-label">


### PR DESCRIPTION
closes #164 

# Pull Request Description

## Description
This pull request improves the Campaigns page by adding skeleton loading, displaying unlockable skills per campaign, and aligning the XP calculation to match the game engine logic.

## Changes

### Campaigns Page & Styling
- **Skeleton Loading:** Added a simulated `800ms` loading state on mount, rendering placeholder pulsing skeleton elements matching the card layouts.
- **Unlockable Skills:** Dynamically extracts the union of `conceptsIntroduced` across all missions in each chapter and renders them as small, monospace badges on each campaign card.
- **Responsive Layout:** Replaced the hardcoded height limits of the campaign cards with `min-height` and `height: auto` to prevent any text or badge overflows, ensuring consistent rendering across screen resolutions.

### Systems & Alignment
- **XP Alignment:** Imported and utilized `getLevelFromXP` directly from `src/systems/gameEngine.js` in `src/pages/Campaigns.jsx`, replacing the hardcoded formula `Math.floor(xp / 300) + 1` to guarantee consistent player levels across both views.

## Verification
- Run local unit tests: `node node_modules/vitest/vitest.mjs run` — All 52 tests passed.
- Verified loading animation and responsive grid adjustments in standard layouts.