### PR TITLE
feat: add reset progress confirmation dialog to GameStateContext

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import ScrollToTop from "./components/ScrollToTop";
 // 1. Import the ErrorBoundary
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { ToastProvider } from "./systems/ToastContext";
+import { GameStateProvider } from "./systems/GameStateContext";
 import LoadingScreen from "./components/LoadingScreen";
 import { loadProgress, saveProgress } from "./systems/storage";
 import { updateStreak } from "./systems/gameEngine";
@@ -32,25 +33,27 @@ export default function App() {
   return (
     <ErrorBoundary>
       <ToastProvider>
-        <ScrollToTop />
-        <div className="app">
-          <Navbar />
-          <main className="main-content">
-            <Suspense fallback={<LoadingScreen />}>
-              <Routes>
-                <Route path="/" element={<Home />} />
-                <Route path="/missions" element={<MissionMap />} />
-                <Route path="/campaigns" element={<Campaigns />} />
-                <Route path="/mission/:missionId" element={<MissionDetail />} />
-                <Route path="/profile" element={<Profile />} />
-                <Route path="/journal" element={<Journal />} />
-                <Route path="/skills" element={<SkillTree />} />
-                <Route path="*" element={<NotFound />} />
-              </Routes>
-            </Suspense>
-          </main>
-          <Footer />
-        </div>
+        <GameStateProvider>
+          <ScrollToTop />
+          <div className="app">
+            <Navbar />
+            <main className="main-content">
+              <Suspense fallback={<LoadingScreen />}>
+                <Routes>
+                  <Route path="/" element={<Home />} />
+                  <Route path="/missions" element={<MissionMap />} />
+                  <Route path="/campaigns" element={<Campaigns />} />
+                  <Route path="/mission/:missionId" element={<MissionDetail />} />
+                  <Route path="/profile" element={<Profile />} />
+                  <Route path="/journal" element={<Journal />} />
+                  <Route path="/skills" element={<SkillTree />} />
+                  <Route path="*" element={<NotFound />} />
+                </Routes>
+              </Suspense>
+            </main>
+            <Footer />
+          </div>
+        </GameStateProvider>
       </ToastProvider>
     </ErrorBoundary>
   );

--- a/src/components/ConfirmationDialog.css
+++ b/src/components/ConfirmationDialog.css
@@ -1,0 +1,83 @@
+.dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-modal);
+  animation: fadeIn 0.25s ease-out;
+}
+
+.dialog-content {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-accent);
+  border-radius: var(--radius-xl);
+  padding: var(--space-2xl);
+  max-width: 440px;
+  width: 90%;
+  text-align: center;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.5), var(--shadow-glow-cyan);
+  animation: scaleIn 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.dialog-icon {
+  font-size: 3rem;
+  margin-bottom: var(--space-md);
+  animation: pulse 2s infinite;
+}
+
+.dialog-title {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 800;
+  margin-bottom: var(--space-sm);
+  background: linear-gradient(135deg, #ef4444, var(--gold));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.dialog-message {
+  color: var(--text-secondary);
+  margin-bottom: var(--space-xl);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-md);
+}
+
+.btn-confirm {
+  background: linear-gradient(135deg, var(--red), #b91c1c);
+  color: var(--text-primary);
+  box-shadow: 0 0 15px rgba(239, 68, 68, 0.3);
+}
+
+.btn-confirm:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 0 25px rgba(239, 68, 68, 0.5);
+}
+
+.btn-confirm:focus-visible {
+  outline: 2px solid var(--red);
+  outline-offset: 2px;
+}
+
+.btn-cancel:focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: 2px;
+}
+
+@keyframes pulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.08); }
+  100% { transform: scale(1); }
+}

--- a/src/components/ConfirmationDialog.jsx
+++ b/src/components/ConfirmationDialog.jsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useRef } from "react";
+import "./ConfirmationDialog.css";
+
+export default function ConfirmationDialog({
+  isOpen,
+  title,
+  message,
+  confirmText,
+  cancelText,
+  onConfirm,
+  onCancel,
+}) {
+  const dialogRef = useRef(null);
+
+  // Keyboard navigation & Focus trapping
+  useEffect(() => {
+    if (!isOpen || !dialogRef.current) return;
+
+    const dialogElement = dialogRef.current;
+    const focusableSelectors = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+    const focusableElements = dialogElement.querySelectorAll(focusableSelectors);
+
+    if (focusableElements.length === 0) return;
+
+    // Focus the cancel button (usually the first button or btn-cancel) by default for safety in destructive actions
+    const cancelBtn = Array.from(focusableElements).find(
+      (el) => el.classList.contains("btn-cancel") || el.getAttribute("data-cancel") === "true"
+    );
+    if (cancelBtn) {
+      cancelBtn.focus();
+    } else {
+      focusableElements[0].focus();
+    }
+
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+        return;
+      }
+
+      if (e.key !== "Tab") return;
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === firstElement) {
+          e.preventDefault();
+          lastElement.focus();
+        }
+      } else {
+        if (document.activeElement === lastElement) {
+          e.preventDefault();
+          firstElement.focus();
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onCancel]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="dialog-overlay"
+      onClick={onCancel}
+      role="presentation"
+    >
+      <div
+        className="dialog-content"
+        ref={dialogRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="dialog-title"
+        aria-describedby="dialog-description"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="dialog-icon" role="img" aria-hidden="true">
+          ⚠️
+        </div>
+        <h2 id="dialog-title" className="dialog-title">
+          {title}
+        </h2>
+        <p id="dialog-description" className="dialog-message">
+          {message}
+        </p>
+        <div className="dialog-actions">
+          <button
+            type="button"
+            className="btn btn-secondary btn-cancel"
+            onClick={onCancel}
+            data-cancel="true"
+          >
+            {cancelText}
+          </button>
+          <button
+            type="button"
+            className="btn btn-confirm"
+            onClick={onConfirm}
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,14 +1,14 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Menu, X, Sun, Moon, Globe, ChevronDown } from "lucide-react";
-import { loadProfile } from "../systems/storage";
 import { useTranslation } from "../i18n/useTranslation";
+import { useGameState } from "../systems/GameStateContext";
 
 export default function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
   const [langOpen, setLangOpen] = useState(false);
   const location = useLocation();
-  const profile = loadProfile();
+  const { profile } = useGameState();
   const langRef = useRef(null);
 
   const { t, language, setLanguage, languages } = useTranslation();

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -10,6 +10,7 @@
     "close": "Close",
     "save": "Save",
     "cancel": "Cancel",
+    "confirm": "Confirm",
     "loading": "Loading…",
     "all": "All",
     "level": "Level",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -10,6 +10,7 @@
     "close": "Cerrar",
     "save": "Guardar",
     "cancel": "Cancelar",
+    "confirm": "Confirmar",
     "loading": "Cargando…",
     "all": "Todas",
     "level": "Nivel",

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -3,12 +3,8 @@ import { Link } from "react-router-dom";
 import "./Profile.css";
 
 import {
-  loadProgress,
   importProgress,
   exportProgress,
-  resetProgress,
-  loadProfile,
-  saveProfile,
 } from "../systems/storage";
 
 import { getXPProgress, BADGES } from "../systems/gameEngine";
@@ -17,6 +13,7 @@ import { avatars } from "../data/avatars";
 
 // Hooks and Utilities
 import { useToast } from "../systems/ToastContext";
+import { useGameState } from "../systems/GameStateContext";
 import { logActivity, ACTIVITY_TYPES } from "../systems/activityLogger";
 import useDocumentTitle from '../systems/useDocumentTitle';
 import { useTranslation } from "../i18n/useTranslation";
@@ -28,10 +25,13 @@ export default function Profile() {
   useDocumentTitle('Profile');
   const { showToast } = useToast();
   const { t, language } = useTranslation();
-  const [state, setState] = useState(loadProgress());
-
-  // Safe profile initialization
-  const [profile, setProfile] = useState(() => loadProfile());
+  const {
+    progress: state,
+    profile,
+    updateProgress,
+    updateProfile,
+    resetProgress,
+  } = useGameState();
 
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState(profile.name || "");
@@ -52,8 +52,7 @@ export default function Profile() {
       avatar,
     };
 
-    saveProfile(updated);
-    setProfile(updated);
+    updateProfile(updated);
     setEditing(false);
 
     // Trigger global success toast alert
@@ -86,7 +85,12 @@ export default function Profile() {
 
     try {
       const newState = await importProgress(file);
-      setState(newState);
+      if (newState.state) {
+        updateProgress(newState.state);
+      }
+      if (newState.profile) {
+        updateProfile(newState.profile);
+      }
       setImportStatus("✅ Progress imported successfully!");
       
       // Trigger global success toast alert
@@ -104,10 +108,9 @@ export default function Profile() {
     setTimeout(() => setImportStatus(""), 3000);
   };
 
-  const handleReset = () => {
-    if (window.confirm(t("profile.data.confirmReset"))) {
-      const newState = resetProgress();
-      setState(newState);
+  const handleReset = async () => {
+    const confirmed = await resetProgress();
+    if (confirmed) {
       setImportStatus("🗑️ Progress reset.");
       
       // Trigger global warning toast alert

--- a/src/systems/GameStateContext.jsx
+++ b/src/systems/GameStateContext.jsx
@@ -1,0 +1,88 @@
+import React, { createContext, useContext, useState, useCallback } from "react";
+import {
+  loadProgress,
+  saveProgress,
+  resetProgress as resetProgressStorage,
+  loadProfile,
+  saveProfile
+} from "./storage";
+import ConfirmationDialog from "../components/ConfirmationDialog";
+import { useTranslation } from "../i18n/useTranslation";
+
+const GameStateContext = createContext(null);
+
+export const GameStateProvider = ({ children }) => {
+  const { t } = useTranslation();
+  const [progress, setProgressState] = useState(() => loadProgress());
+  const [profile, setProfileState] = useState(() => loadProfile());
+  const [isResetConfirmOpen, setIsResetConfirmOpen] = useState(false);
+  const [resetConfirmResolve, setResetConfirmResolve] = useState(null);
+
+  const updateProgress = useCallback((newProgress) => {
+    saveProgress(newProgress);
+    setProgressState(newProgress);
+  }, []);
+
+  const updateProfile = useCallback((newProfile) => {
+    saveProfile(newProfile);
+    setProfileState(newProfile);
+  }, []);
+
+  const resetProgress = useCallback(() => {
+    setIsResetConfirmOpen(true);
+    return new Promise((resolve) => {
+      setResetConfirmResolve(() => resolve);
+    });
+  }, []);
+
+  const handleConfirmReset = useCallback(() => {
+    const defaultState = resetProgressStorage();
+    setProgressState(defaultState);
+    setIsResetConfirmOpen(false);
+
+    if (resetConfirmResolve) {
+      resetConfirmResolve(true);
+      setResetConfirmResolve(null);
+    }
+  }, [resetConfirmResolve]);
+
+  const handleCancelReset = useCallback(() => {
+    setIsResetConfirmOpen(false);
+
+    if (resetConfirmResolve) {
+      resetConfirmResolve(false);
+      setResetConfirmResolve(null);
+    }
+  }, [resetConfirmResolve]);
+
+  return (
+    <GameStateContext.Provider
+      value={{
+        progress,
+        profile,
+        updateProgress,
+        updateProfile,
+        resetProgress,
+      }}
+    >
+      {children}
+      <ConfirmationDialog
+        isOpen={isResetConfirmOpen}
+        title={t("profile.data.reset")}
+        message={t("profile.data.confirmReset")}
+        confirmText={t("common.confirm") || "Confirm"}
+        cancelText={t("common.cancel") || "Cancel"}
+        onConfirm={handleConfirmReset}
+        onCancel={handleCancelReset}
+      />
+    </GameStateContext.Provider>
+  );
+};
+
+export const useGameState = () => {
+  const context = useContext(GameStateContext);
+  if (!context) {
+    throw new Error("useGameState must be used within a GameStateProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
## Description

Closes #168

Replaces the native `window.confirm` dialog with a fully custom, accessible confirmation modal before resetting game progress. Introduces a new `GameStateContext` to manage progress and profile state globally across the application.

---

## Changes

### ✨ New: `ConfirmationDialog` component
- Reusable modal dialog rendered at the app level
- Smooth `fadeIn` + `scaleIn` CSS animations on entry
- Pulsing ⚠️ warning icon for visual urgency
- Danger-red confirm button with glow effect
- Cancel button auto-focused on open to protect against accidental resets

### ✨ New: `GameStateContext`
- Provides `progress`, `profile`, `updateProgress`, `updateProfile`, and `resetProgress` to any component via `useGameState()`
- `resetProgress()` returns a **Promise** resolved by the dialog — no more `window.confirm`
- Renders `ConfirmationDialog` as a singleton at the provider level

### 🔧 Modified: `App.jsx`
- Application is now wrapped in `<GameStateProvider>` (inside `<ToastProvider>` so toast notifications work within)

### 🔧 Modified: `Profile.jsx`
- Replaced local `loadProgress` / `loadProfile` / `saveProfile` state with `useGameState()` hook
- `handleReset` is now `async` — awaits the custom dialog result
- Import/export handlers use `updateProgress` / `updateProfile` from context

### 🔧 Modified: `Navbar.jsx`
- Replaced static `loadProfile()` call with reactive `profile` from context
- Avatar and name in the nav bar now update instantly after profile edits

### 🌐 Modified: `en.json` / `es.json`
- Added `common.confirm` key (`"Confirm"` / `"Confirmar"`)

---

## Accessibility

| Criterion | Status |
|---|---|
| Cancel button auto-focused on open | ✅ |
| Escape key closes dialog without reset | ✅ |
| Tab / Shift-Tab focus trapped inside dialog | ✅ |
| `role="alertdialog"`, `aria-modal`, `aria-labelledby`, `aria-describedby` | ✅ |
| Backdrop click cancels dialog | ✅ |

---

## Acceptance Criteria

- [x] Clicking Reset opens a confirmation dialog
- [x] Cancelling the dialog does not reset any progress
- [x] Confirming the dialog resets progress and shows a warning toast
- [x] Fully keyboard-accessible

---

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update