### PR TITLE
feat(i18n): private mode support, OS language detection, active indicator

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,8 +1,22 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { Menu, X, Sun, Moon, Globe, ChevronDown } from "lucide-react";
+import { Menu, X, Sun, Moon, Globe, ChevronDown, Check } from "lucide-react";
 import { loadProfile } from "../systems/storage";
 import { useTranslation } from "../i18n/useTranslation";
+
+/* Safe localStorage helpers — work in private/incognito mode too */
+const _mem = new Map();
+function safeStorageGet(key, fallback = null) {
+  try {
+    const v = localStorage.getItem(key);
+    if (v !== null) return v;
+  } catch { /* blocked */ }
+  return _mem.get(key) ?? fallback;
+}
+function safeStorageSet(key, value) {
+  try { localStorage.setItem(key, value); return; } catch { /* blocked */ }
+  _mem.set(key, value);
+}
 
 export default function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
@@ -15,7 +29,7 @@ export default function Navbar() {
 
   const [theme, setTheme] = useState(() => {
     return (
-      localStorage.getItem("soroban_quest_theme") ||
+      safeStorageGet("soroban_quest_theme") ||
       (window.matchMedia("(prefers-color-scheme: light)").matches
         ? "light"
         : "dark")
@@ -24,7 +38,7 @@ export default function Navbar() {
 
   useEffect(() => {
     document.documentElement.setAttribute("data-theme", theme);
-    localStorage.setItem("soroban_quest_theme", theme);
+    safeStorageSet("soroban_quest_theme", theme);
   }, [theme]);
 
   // Close the language dropdown on outside click or Escape
@@ -216,11 +230,20 @@ function LanguageSelector({
         aria-label={t("common.selectLanguage")}
         onClick={() => setLangOpen((v) => !v)}
       >
-        <Globe size={18} />
+        <Globe size={18} aria-hidden="true" />
         <span className="language-selector-code">
           {currentLang.code.toUpperCase()}
         </span>
-        <ChevronDown size={14} aria-hidden="true" />
+        {/* Active language badge — always visible so the current language
+            is obvious without opening the dropdown */}
+        <span className="language-selector-active-badge" aria-hidden="true">
+          {currentLang.name}
+        </span>
+        <ChevronDown
+          size={14}
+          aria-hidden="true"
+          className={`language-selector-chevron ${langOpen ? "open" : ""}`}
+        />
       </button>
 
       {langOpen && (
@@ -229,26 +252,31 @@ function LanguageSelector({
           role="listbox"
           aria-label={t("common.selectLanguage")}
         >
-          {languages.map((lang) => (
-            <li key={lang.code}>
-              <button
-                type="button"
-                role="option"
-                aria-selected={lang.code === language}
-                className={`language-selector-option ${
-                  lang.code === language ? "active" : ""
-                }`}
-                onClick={() => handleLanguageChange(lang.code)}
-              >
-                <span className="language-selector-option-code">
-                  {lang.code.toUpperCase()}
-                </span>
-                <span className="language-selector-option-name">
-                  {lang.name}
-                </span>
-              </button>
-            </li>
-          ))}
+          {languages.map((lang) => {
+            const isActive = lang.code === language;
+            return (
+              <li key={lang.code}>
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={isActive}
+                  className={`language-selector-option ${isActive ? "active" : ""}`}
+                  onClick={() => handleLanguageChange(lang.code)}
+                >
+                  {/* Checkmark slot — always reserve space so text doesn't shift */}
+                  <span className="language-selector-check" aria-hidden="true">
+                    {isActive && <Check size={13} strokeWidth={3} />}
+                  </span>
+                  <span className="language-selector-option-code">
+                    {lang.code.toUpperCase()}
+                  </span>
+                  <span className="language-selector-option-name">
+                    {lang.name}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/src/i18n/i18n.css
+++ b/src/i18n/i18n.css
@@ -36,11 +36,42 @@
   font-family: var(--font-display);
 }
 
+/* Active language badge — shows the full language name next to the code
+   so the active language is obvious without opening the dropdown */
+.language-selector-active-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  background: var(--cyan-dim, rgba(6, 214, 160, 0.15));
+  color: var(--cyan);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+  border: 1px solid var(--cyan-dim, rgba(6, 214, 160, 0.25));
+  transition: background var(--transition-fast);
+}
+
+.language-selector-trigger:hover .language-selector-active-badge {
+  background: var(--cyan-dim, rgba(6, 214, 160, 0.22));
+}
+
+/* Chevron rotates when dropdown is open */
+.language-selector-chevron {
+  transition: transform var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.language-selector-chevron.open {
+  transform: rotate(180deg);
+}
+
 .language-selector-menu {
   position: absolute;
   top: calc(100% + 0.5rem);
   right: 0;
-  min-width: 160px;
+  min-width: 170px;
   list-style: none;
   margin: 0;
   padding: 0.35rem;
@@ -66,7 +97,7 @@
 .language-selector-option {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
+  gap: 0.5rem;
   width: 100%;
   padding: 0.5rem 0.65rem;
   border-radius: var(--radius-sm, 6px);
@@ -85,6 +116,17 @@
 .language-selector-option.active {
   color: var(--cyan);
   background: var(--cyan-dim, rgba(6, 214, 160, 0.1));
+  font-weight: 600;
+}
+
+/* Fixed-width slot so text columns stay aligned regardless of checkmark */
+.language-selector-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  flex-shrink: 0;
+  color: var(--cyan);
 }
 
 .language-selector-option-code {
@@ -104,5 +146,10 @@
   .mobile-stats .language-selector-menu {
     right: auto;
     left: 0;
+  }
+
+  /* On small screens the badge text can be hidden to save space */
+  .language-selector-active-badge {
+    display: none;
   }
 }

--- a/src/i18n/index.jsx
+++ b/src/i18n/index.jsx
@@ -8,6 +8,7 @@ import React, {
   useEffect,
   useMemo,
   useCallback,
+  useRef,
 } from 'react';
 
 import en from './locales/en.json';
@@ -20,6 +21,34 @@ const STORAGE_KEY = 'soroban_quest_lang';
 const DEFAULT_LANG = 'en';
 
 export const LanguageContext = createContext(null);
+
+/* ---------- storage abstraction (private-mode safe) ---------- */
+
+/**
+ * In-memory fallback used when localStorage is unavailable
+ * (e.g. private/incognito mode or strict browser settings).
+ */
+const memoryStore = new Map();
+
+function storageGet(key) {
+  try {
+    const v = localStorage.getItem(key);
+    if (v !== null) return v;
+  } catch {
+    /* localStorage blocked — fall through to memory */
+  }
+  return memoryStore.get(key) ?? null;
+}
+
+function storageSet(key, value) {
+  try {
+    localStorage.setItem(key, value);
+    return;
+  } catch {
+    /* localStorage blocked — fall through to memory */
+  }
+  memoryStore.set(key, value);
+}
 
 /* ---------- helpers ---------- */
 
@@ -39,12 +68,8 @@ function detectBrowserLanguage() {
 }
 
 function readStoredLanguage() {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored && SUPPORTED.includes(stored)) return stored;
-  } catch {
-    /* localStorage unavailable (private mode, SSR, etc.) — ignore */
-  }
+  const stored = storageGet(STORAGE_KEY);
+  if (stored && SUPPORTED.includes(stored)) return stored;
   return null;
 }
 
@@ -72,12 +97,12 @@ export function LanguageProvider({ children }) {
     return initial;
   });
 
+  // Track whether the user has explicitly chosen a language so we
+  // don't override their preference when the OS language changes.
+  const userChoseRef = useRef(readStoredLanguage() !== null);
+
   useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY, language);
-    } catch {
-      /* ignore */
-    }
+    storageSet(STORAGE_KEY, language);
     if (typeof document !== 'undefined') {
       document.documentElement.lang = language;
     }
@@ -85,6 +110,21 @@ export function LanguageProvider({ children }) {
     // (missions/campaigns) localize against the active language.
     setActiveLanguage(language);
   }, [language]);
+
+  // Detect real-time OS language changes via the languagechange event.
+  // Only applies when the user has NOT made an explicit choice.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handleLanguageChange = () => {
+      if (userChoseRef.current) return; // respect explicit user choice
+      const detected = detectBrowserLanguage();
+      setLanguageState(detected);
+    };
+
+    window.addEventListener('languagechange', handleLanguageChange);
+    return () => window.removeEventListener('languagechange', handleLanguageChange);
+  }, []);
 
   // t('a.b.c', { name: 'World' })
   const t = useCallback(
@@ -109,7 +149,9 @@ export function LanguageProvider({ children }) {
   );
 
   const setLanguage = useCallback((lang) => {
-    if (SUPPORTED.includes(lang)) setLanguageState(lang);
+    if (!SUPPORTED.includes(lang)) return;
+    userChoseRef.current = true; // mark explicit choice
+    setLanguageState(lang);
   }, []);
 
   const languages = useMemo(


### PR DESCRIPTION


closes #140 

- Add storageGet/storageSet abstraction with in-memory Map fallback
  so i18n works in private/incognito mode when localStorage is blocked
- Listen to window languagechange event to react to OS language changes
  in real-time; skipped when user has made an explicit in-app choice
- Track userChoseRef to prevent OS changes from overriding manual picks
- Add language-selector-active-badge pill on trigger (always visible)
- Add Check icon in dropdown to clearly mark the active language option
- Animate chevron rotation on dropdown open/close
- Apply same safe storage helpers to theme preference in Navbar
