### PR TITLE
fix(i18n): add missing Spanish translations for navbar and common keys

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -19,14 +19,21 @@
     "complete": "Complete",
     "completed": "Completed",
     "locked": "Locked",
-    "unlocked": "Unlocked"
+    "unlocked": "Unlocked",
+    "skipToContent": "Skip to main content"
   },
   "navbar": {
     "home": "Home",
     "campaigns": "Campaigns",
     "missions": "Missions",
     "profile": "Profile",
-    "journal": "Journal"
+    "journal": "Journal",
+    "ariaMain": "Main navigation",
+    "ariaHome": "Go to home page",
+    "ariaMobile": "Mobile navigation menu",
+    "userProfile": "User profile:",
+    "openMenu": "Open navigation menu",
+    "closeMenu": "Close navigation menu"
   },
   "home": {
     "badge": "✨ Zero setup • No wallet needed • Open source",
@@ -158,6 +165,12 @@
       "log": {
         "exported": "Exported adventure progress",
         "imported": "Imported adventure progress from file"
+      },
+      "toast": {
+        "exported": "Progress exported successfully!",
+        "imported": "Progress imported successfully!",
+        "importFailed": "Could not import file. Check the format.",
+        "resetDone": "🗑️ Progress reset."
       }
     }
   },
@@ -220,6 +233,7 @@
     "back": "← Back to Campaigns",
     "completeOf": "{{completed}}/{{total}} Complete",
     "lore": {
+      "iconLabel": "Chapter lore scroll",
       "modalTitle": "Chapter Introduction",
       "beginChapter": "Begin Chapter {{number}}"
     }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -19,14 +19,21 @@
     "complete": "Completa",
     "completed": "Completada",
     "locked": "Bloqueada",
-    "unlocked": "Desbloqueada"
+    "unlocked": "Desbloqueada",
+    "skipToContent": "Saltar al contenido principal"
   },
   "navbar": {
     "home": "Inicio",
     "campaigns": "Campañas",
     "missions": "Misiones",
     "profile": "Perfil",
-    "journal": "Diario"
+    "journal": "Diario",
+    "ariaMain": "Navegación principal",
+    "ariaHome": "Ir a la página de inicio",
+    "ariaMobile": "Menú de navegación móvil",
+    "userProfile": "Perfil de usuario:",
+    "openMenu": "Abrir menú de navegación",
+    "closeMenu": "Cerrar menú de navegación"
   },
   "home": {
     "badge": "✨ Sin configuración • Sin billetera • Código abierto",
@@ -158,6 +165,12 @@
       "log": {
         "exported": "Progreso de la aventura exportado",
         "imported": "Progreso de la aventura importado desde archivo"
+      },
+      "toast": {
+        "exported": "¡Progreso exportado correctamente!",
+        "imported": "¡Progreso importado correctamente!",
+        "importFailed": "No se pudo importar el archivo. Verifica el formato.",
+        "resetDone": "🗑️ Progreso restablecido."
       }
     }
   },
@@ -220,6 +233,7 @@
     "back": "← Volver a campañas",
     "completeOf": "{{completed}}/{{total}} completadas",
     "lore": {
+      "iconLabel": "Pergamino de historia del capítulo",
       "modalTitle": "Introducción del capítulo",
       "beginChapter": "Comenzar capítulo {{number}}"
     }


### PR DESCRIPTION
## What does this PR do?

Adds missing translation keys to both `en.json` and `es.json` that were referenced in components but absent from the locale files, causing silent fallbacks to raw key strings when the language is set to Spanish.

**`common`**
- `skipToContent` — used in the Navbar skip-to-content accessibility link

**`navbar`**
- `ariaMain` — `aria-label` on the `<nav>` element
- `ariaHome` — `aria-label` on the logo link
- `ariaMobile` — `aria-label` on the mobile menu drawer
- `userProfile` — screen-reader-only label rendered before the profile name
- `openMenu` / `closeMenu` — hamburger button `aria-label` (toggled by menu state)

**`profile.data.toast`**
- `exported`, `imported`, `importFailed`, `resetDone` — used in `Profile.jsx` `showToast()` calls for all data management actions

**`campaigns.lore`**
- `iconLabel` — `aria-label` on the 📜 scroll icon inside the lore modal

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Content (new mission or educational material)
- [ ] Documentation
- [ ] Refactor

## Testing checklist

- [ ] `npm run build` passes
- [ ] `npm run lint` passes (if available)
- [x] Tested locally in the browser
- [x] All existing pages still work correctly
- [ ] Screenshots attached (if UI change)

## Screenshots

No visual changes — this fix only restores correct translated strings in place of raw key fallbacks when the UI language is set to Spanish.

## Related issue

Closes #130
