### PR TITLE
fix: remove broken /glossary link from Footer.jsx and clean up orphaned translation keys

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -108,8 +108,7 @@
       "heading": "Platform",
       "home": "Home",
       "missions": "Missions",
-      "profile": "Profile",
-      "glossary": "Glossary"
+      "profile": "Profile"
     },
     "resources": {
       "heading": "Resources",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -108,8 +108,7 @@
       "heading": "Plataforma",
       "home": "Inicio",
       "missions": "Misiones",
-      "profile": "Perfil",
-      "glossary": "Glosario"
+      "profile": "Perfil"
     },
     "resources": {
       "heading": "Recursos",


### PR DESCRIPTION
The broken internal /glossary route link in Footer.jsx was already
replaced with a valid external URL (Stellar encyclopedia) in a prior
commit. This change removes the now-unused footer.platform.glossary
translation key from both en.json and es.json.

Closes #215
