### PR TITLE
feat(i18n): add French (fr) localization support

### DIFF
--- a/src/data/campaigns.js
+++ b/src/data/campaigns.js
@@ -47,6 +47,21 @@ Completa estos contratos fundamentales para desbloquear el **Capítulo 2: Bóved
 
 **0/2 misiones** • **Nivel 1 requerido**`,
       },
+      fr: {
+        title: 'Chapitre 1 : L\'Éveil',
+        description: 'Maîtrisez vos premiers contrats Soroban. Forgez votre voie en tant que Gardien Stellaire.',
+        lore: `# 🌌 Chapitre 1 : L'Éveil
+
+Vous vous tenez aux portes de la **Citadelle Stellaire**, en orbite à la lisière de l'espace connu. Les anciens **Gardiens de Soroban** ont perçu votre arrivée.
+
+*"Encore un chercheur,"* murmure le Gardien Ancien. *"La blockchain appelle ceux qui possèdent le code pour répondre."*
+
+## Votre Destinée Vous Attend
+
+Complétez ces contrats fondamentaux pour débloquer le **Chapitre 2 : Chambre de la Mémoire**.
+
+**0/2 missions** • **Niveau 1 requis**`,
+      },
     },
     heroImage: 'linear-gradient(135deg, #06d6a0 0%, #8b5cf6 50%, #f59e0b 100%)',
     chapterNumber: 1,
@@ -86,6 +101,21 @@ La **Torre de Señales** se desvanece tras de ti. Desciendes a la **Bóveda de l
 Domina la gestión de estado para acceder al **Capítulo 3: Forja de Tokens**.
 
 **0/2 misiones** • **Nivel 3 requerido**`,
+      },
+      fr: {
+        title: 'Chapitre 2 : Chambre de la Mémoire',
+        description: 'Débloquez le stockage persistant et le contrôle d\'accès. La mémoire définit le véritable pouvoir.',
+        lore: `# 🔐 Chapitre 2 : Chambre de la Mémoire
+
+La **Tour des Signaux** s'estompe derrière vous. Vous descendez dans la **Chambre de la Mémoire**, où la sagesse ancestrale perdure à travers les éons.
+
+*"Un contrat sans mémoire n'est qu'une pensée éphémère,"* murmure le Gardien de la Chambre. *"Pour perdurer, vous devez stocker et protéger."*
+
+## La Deuxième Épreuve
+
+Maîtrisez la gestion de l'état pour accéder au **Chapitre 3 : Forge de Jetons**.
+
+**0/2 missions** • **Niveau 3 requis**`,
       },
     },
     heroImage: 'linear-gradient(135deg, #8b5cf6 0%, #f59e0b 50%, #ef4444 100%)',
@@ -127,6 +157,21 @@ Completa la Forja de Tokens para obtener el estatus de **Guardián Legendario**.
 
 **0/3 misiones** • **Nivel 5 requerido**`,
       },
+      fr: {
+        title: 'Chapitre 3 : Forge de Jetons',
+        description: 'Frappez des jetons, maîtrisez les verrous temporels, gouvernez avec la multi-signature. Devenez le Gardien Maître.',
+        lore: `# ⚒️ Chapitre 3 : Forge de Jetons
+
+La **Porte du Temps** vibre de puissance. Vous entrez dans la **Forge de Jetons** — le cœur de l'économie Stellar.
+
+*"La véritable maîtrise crée une valeur qui perdure,"* déclare le Maître Forgeron. *"Jetons, temps, confiance — forgez-les tous."*
+
+## Défi Final
+
+Complétez la Forge de Jetons pour obtenir le statut de **Gardien Légendaire**.
+
+**0/3 missions** • **Niveau 5 requis**`,
+      },
     },
     heroImage: 'linear-gradient(135deg, #f59e0b 0%, #ef4444 50%, #06d6a0 100%)',
     chapterNumber: 3,
@@ -166,6 +211,21 @@ Más allá del Salón de los Pactos, descubres la **Fortaleza de Datos** — un 
 Construye contratos basados en datos para desbloquear el **Capítulo 5: Protocolos Avanzados**.
 
 **0/3 misiones** • **Nivel 7 requerido**`,
+      },
+      fr: {
+        title: 'Chapitre 4 : Forteresse de Données',
+        description: 'Maîtrisez la gestion d\'état complexe avec les Map, les événements et les approbations déléguées.',
+        lore: `# 🏦 Chapitre 4 : Forteresse de Données
+
+Au-delà de la Salle des Pactes, vous découvrez la **Forteresse de Données** — un vaste dépôt où l'état sophistiqué est conçu.
+
+*"Les données sont le fondement de tous les grands contrats,"* déclare l'Architecte. *"Apprenez à gérer l'état multi-utilisateur, à émettre des événements et à déléguer l'autorité."*
+
+## La Quatrième Épreuve
+
+Construisez des contrats axés sur les données pour débloquer le **Chapitre 5 : Protocoles Avancés**.
+
+**0/3 missions** • **Niveau 7 requis**`,
       },
     },
     heroImage: 'linear-gradient(135deg, #06d6a0 0%, #118ab2 50%, #073b4c 100%)',
@@ -207,6 +267,21 @@ Domina los patrones de protocolos avanzados para llegar al **Capítulo 6: Sistem
 
 **0/3 misiones** • **Nivel 9 requerido**`,
       },
+      fr: {
+        title: 'Chapitre 5 : Protocoles Avancés',
+        description: 'Construisez des protocoles DeFi du monde réel — financement participatif, séquestre et abonnements.',
+        lore: `# 🔄 Chapitre 5 : Protocoles Avancés
+
+L'**Arène Crowdforge** bourdonne d'énergie. Vous entrez dans le royaume des protocoles DeFi du monde réel.
+
+*"Voici les contrats qui alimentent la nouvelle économie,"* dit le Pionnier des Protocoles. *"Financement participatif, séquestre, abonnements — construisez-les tous."*
+
+## La Cinquième Épreuve
+
+Maîtrisez les modèles de protocoles avancés pour atteindre le **Chapitre 6 : Systèmes de Production**.
+
+**0/3 missions** • **Niveau 9 requis**`,
+      },
     },
     heroImage: 'linear-gradient(135deg, #ef476f 0%, #ffd166 50%, #06d6a0 100%)',
     chapterNumber: 5,
@@ -247,6 +322,21 @@ Completa todos los Sistemas de Producción para ganar el título de **Arquitecto
 
 **0/4 misiones** • **Nivel 12 requerido**`,
       },
+      fr: {
+        title: 'Chapitre 6 : Systèmes de Production',
+        description: 'Déployez des contrats de niveau production — flash loans, RBAC, oracles et gouvernance.',
+        lore: `# ⚡ Chapitre 6 : Systèmes de Production
+
+La **Chambre de la Foudre** crépite de puissance. Vous avez atteint le sommet du développement Soroban.
+
+*"Vous comptez parmi les meilleurs ingénieurs de contrats de l'écosystème Stellar,"* proclame le Grand Ancien. *"Flash loans, sécurité basée sur les rôles, oracles de prix, gouvernance on-chain — maîtrisez les systèmes qui définissent la DeFi."*
+
+## Épreuve Finale
+
+Complétez tous les Systèmes de Production pour gagner le titre d'**Architecte Stellaire**.
+
+**0/4 missions** • **Niveau 12 requis**`,
+      },
     },
     heroImage: 'linear-gradient(135deg, #118ab2 0%, #073b4c 50%, #06d6a0 100%)',
     chapterNumber: 6,
@@ -286,6 +376,21 @@ La **Forja de Vulnerabilidades** yace en las profundidades de la Ciudadela. Aqu�
 Arregla vulnerabilidades de seguridad para completar el desafío de Seguridad y CTF.
 
 **0/2 misiones** • **Nivel 14 requerido**`,
+      },
+      fr: {
+        title: 'Chapitre 7 : Sécurité et CTF',
+        description: 'Traquez les vulnérabilités et corrigez les failles de sécurité dans des contrats compromis.',
+        lore: `# 🛡️ Chapitre 7 : Sécurité et CTF
+
+La **Forge des Vulnérabilités** repose dans les profondeurs de la Citadelle. Ici, les contrats brisés sont restaurés.
+
+*"Un gardien doit connaître les failles avant que l'ennemi ne les exploite,"* avertit le Sage de la Sécurité. *"Réentrance, contrôle d'accès, dépassement — affrontez-les tous."*
+
+## Le Défi de Sécurité
+
+Corrigez les vulnérabilités de sécurité pour compléter le défi Sécurité et CTF.
+
+**0/2 missions** • **Niveau 14 requis**`,
       },
     },
     heroImage: 'linear-gradient(135deg, #ef4444 0%, #dc2626 50%, #7f1d1d 100%)',

--- a/src/data/missions.js
+++ b/src/data/missions.js
@@ -67,6 +67,42 @@ Completa la plantilla de código para pasar todas las verificaciones. ¡Los Guar
                     'La línea de retorno completa: `vec![&env, symbol_short!("Hello"), to]`',
                 ],
             },
+            fr: {
+                title: 'Le Premier Contrat',
+                story: `# 🌌 L'Éveil
+
+Tu te tiens devant les portes de la **Citadelle Stellaire**, une forteresse scintillante en orbite au bord de l'espace connu. Les Gardiens de Soroban ont perçu ton arrivée.
+
+*"Encore un chercheur,"* murmure le Gardien Ancien. *"Pour prouver ta valeur, tu dois forger ton premier contrat intelligent."*
+
+## Ta Mission
+
+Crée ton premier contrat intelligent Soroban — un contrat simple avec une fonction \`hello\` qui reçoit un nom et renvoie une salutation.
+
+## Ce Que Tu Apprendras
+
+- Les attributs \`#[contract]\` et \`#[contractimpl]\`
+- Le type \`Env\` — ta porte d'entrée vers la blockchain
+- Le type \`Symbol\` pour les valeurs de type chaîne
+- Comment renvoyer un \`Vec<Symbol>\`
+
+## Concepts Clés
+
+\`\`\`rust
+#[contract]          // Marks your struct as a contract
+#[contractimpl]      // Contains the contract methods
+Env                  // The execution environment
+Symbol               // A small, efficient string type
+\`\`\`
+
+Complète le modèle de code pour passer toutes les vérifications. Les Gardiens attendent ton premier contrat ! ⚔️`,
+                learningGoal: 'Crée ton premier contrat intelligent Soroban avec une fonction hello',
+                hints: [
+                    'Commence par `pub fn hello(env: Env, to: Symbol) -> Vec<Symbol>`',
+                    'Utilise la macro `vec![]` avec `&env` comme premier argument',
+                    'La ligne de retour complète : `vec![&env, symbol_short!("Hello"), to]`',
+                ],
+            },
         },
         template: `#![no_std]
 use soroban_sdk::{contract, contractimpl, symbol_short, vec, Env, Symbol, Vec};
@@ -181,6 +217,41 @@ u32                 // Entero sin signo de 32 bits
                     'La firma de la función greet: `pub fn greet(env: Env, name: Symbol) -> Vec<Symbol>`',
                     'Para count_chars: `pub fn count_chars(env: Env, text: String) -> u32`',
                     'Usa `text.len()` para obtener la longitud de la cadena',
+                ],
+            },
+            fr: {
+                title: 'Protocole de Salutations',
+                story: `# 📡 La Tour de Signaux
+
+La première porte est ouverte. Tu avances vers la **Tour de Signaux**, où les messages se propagent à travers le réseau Stellar.
+
+*"La communication est un pouvoir,"* dit le Gardien de la Tour. *"Ton contrat doit apprendre à gérer les données — accepter des entrées et renvoyer des réponses structurées."*
+
+## Ta Mission
+
+Construis un contrat avec plusieurs fonctions :
+- \`greet\` — reçoit un nom et renvoie une salutation personnalisée
+- \`count_chars\` — reçoit une chaîne et renvoie sa longueur en u32
+
+## Ce Que Tu Apprendras
+
+- Plusieurs fonctions dans un seul contrat
+- Travailler avec le type \`String\` dans Soroban
+- Renvoyer différents types depuis les fonctions
+- La macro \`symbol_short!\`
+
+## Concepts Clés
+
+\`\`\`rust
+String              // Full string type in Soroban
+symbol_short!()     // Create a Symbol from a short literal
+u32                 // Unsigned 32-bit integer
+\`\`\``,
+                learningGoal: 'Construis un contrat multifonction avec différents types de retour',
+                hints: [
+                    'La signature de la fonction greet : `pub fn greet(env: Env, name: Symbol) -> Vec<Symbol>`',
+                    'Pour count_chars : `pub fn count_chars(env: Env, text: String) -> u32`',
+                    'Utilise `text.len()` pour obtenir la longueur de la chaîne',
                 ],
             },
         },
@@ -305,6 +376,41 @@ env.storage().instance().get(&key)          // Leer (devuelve Option)
                     'Usa `env.storage().instance().get(&COUNTER)` para leer el conteo',
                     'Usa `.unwrap_or(0)` para devolver 0 por defecto cuando no existe un valor',
                     'Usa `env.storage().instance().set(&COUNTER, &new_count)` para guardar el nuevo conteo',
+                ],
+            },
+            fr: {
+                title: 'Le Coffre Compteur',
+                story: `# 🔐 Le Coffre de la Mémoire
+
+Tu descends dans le **Coffre de la Mémoire**, où les anciens ont entreposé la sagesse qui persiste à travers le temps.
+
+*"Un contrat sans mémoire est comme un être conscient sans âme,"* murmure le Gardien du Coffre. *"Apprends à stocker et à récupérer — à te souvenir."*
+
+## Ta Mission
+
+Crée un contrat compteur qui conserve sa valeur :
+- \`increment\` — augmente le compteur de 1
+- \`get_count\` — renvoie le décompte actuel
+
+## Ce Que Tu Apprendras
+
+- Le **stockage persistant** avec \`env.storage().instance()\`
+- Lire et écrire l'état
+- Le motif de clé \`Symbol\` pour le stockage
+- Les valeurs par défaut avec \`.unwrap_or()\`
+
+## Concepts Clés
+
+\`\`\`rust
+env.storage().instance().set(&key, &value)  // Write
+env.storage().instance().get(&key)          // Read (returns Option)
+.unwrap_or(default)                         // Default if None
+\`\`\``,
+                learningGoal: 'Utilise le stockage persistant pour créer un contrat compteur avec état',
+                hints: [
+                    'Utilise `env.storage().instance().get(&COUNTER)` pour lire le décompte',
+                    'Utilise `.unwrap_or(0)` pour renvoyer 0 par défaut quand aucune valeur n\'existe',
+                    'Utilise `env.storage().instance().set(&COUNTER, &new_count)` pour enregistrer le nouveau décompte',
                 ],
             },
         },
@@ -439,6 +545,42 @@ Map<Address, Symbol>        // Mapeo clave-valor
                     'La función init almacena el admin: `env.storage().instance().set(&ADMIN, &admin)`',
                     'En register, llama a `who.require_auth()` antes de almacenar',
                     'Almacena con: `env.storage().instance().set(&who, &name)`',
+                ],
+            },
+            fr: {
+                title: 'Registre du Gardien',
+                story: `# 📋 Le Registre du Gardien
+
+La Chambre du Conseil rayonne d'une lumière ancestrale. Devant toi repose le **Registre du Gardien** — un recensement de tous ceux qui ont fait leurs preuves.
+
+*"Pour protéger le royaume, tu dois contrôler qui peut agir,"* déclare le Chef du Conseil. *"Apprends l'art du contrôle d'accès."*
+
+## Ta Mission
+
+Construis un contrat de registre avec contrôle d'accès :
+- \`register\` — enregistre un nouveau gardien (stocke son nom)
+- \`get_guardian\` — récupère le nom d'un gardien par son adresse
+- Une adresse \`admin\` définie lors de l'initialisation
+
+## Ce Que Tu Apprendras
+
+- Le type \`Address\` pour les identités d'utilisateur
+- \`require_auth()\` pour le contrôle d'accès
+- Travailler avec le type \`Map\` pour les paires clé-valeur
+- Les motifs d'initialisation de contrats
+
+## Concepts Clés
+
+\`\`\`rust
+Address                     // Represents an account/identity
+address.require_auth()      // Ensures the caller is authorized
+Map<Address, Symbol>        // Key-value mapping
+\`\`\``,
+                learningGoal: 'Implémente le contrôle d\'accès avec Address et require_auth',
+                hints: [
+                    'La fonction init stocke l\'admin : `env.storage().instance().set(&ADMIN, &admin)`',
+                    'Dans register, appelle `who.require_auth()` avant de stocker',
+                    'Stocke avec : `env.storage().instance().set(&who, &name)`',
                 ],
             },
         },
@@ -584,6 +726,44 @@ let bal: i128 = env.storage().persistent().get(&from).unwrap_or(0);
                     'Para mint: obtén el admin del almacenamiento, llama a admin.require_auth(), luego actualiza el saldo',
                     'Para balance: `env.storage().persistent().get(&account).unwrap_or(0)`',
                     'Para transfer: require_auth del remitente, lee ambos saldos, actualiza ambos',
+                ],
+            },
+            fr: {
+                title: 'La Forge de Tokens',
+                story: `# ⚒️ La Forge de Tokens
+
+Au plus profond de la Citadelle repose la **Forge de Tokens**, où les actifs numériques sont frappés à partir de pure logique.
+
+*"La monnaie est la sève de toute économie,"* dit le Maître Forgeron. *"Tu vas créer un token qui peut être transféré entre les comptes."*
+
+## Ta Mission
+
+Crée un contrat de token simple :
+- \`mint\` — crée des tokens pour une adresse (admin uniquement)
+- \`balance\` — renvoie le solde d'une adresse
+- \`transfer\` — déplace des tokens d'une adresse à une autre
+
+## Ce Que Tu Apprendras
+
+- La gestion des soldes de tokens
+- La logique de transfert avec autorisation
+- Les fonctions restreintes à l'admin
+- L'arithmétique entière pour les soldes
+
+## Concepts Clés
+
+\`\`\`rust
+// Admin check pattern
+admin.require_auth();
+
+// Balance management
+let bal: i128 = env.storage().persistent().get(&from).unwrap_or(0);
+\`\`\``,
+                learningGoal: 'Construis un token de base avec les fonctions mint, balance et transfer',
+                hints: [
+                    'Pour mint : récupère l\'admin depuis le stockage, appelle admin.require_auth(), puis mets à jour le solde',
+                    'Pour balance : `env.storage().persistent().get(&account).unwrap_or(0)`',
+                    'Pour transfer : require_auth de l\'expéditeur, lis les deux soldes, mets à jour les deux',
                 ],
             },
         },
@@ -736,6 +916,41 @@ panic!("message")        // Abortar con un error
                     'Usa `env.ledger().sequence()` para obtener el número de ledger actual',
                     'Compara: `if current_seq < unlock_at { panic!("Still locked"); }`',
                     'Limpia el almacenamiento tras desbloquear: `env.storage().instance().remove(&key)`',
+                ],
+            },
+            fr: {
+                title: 'Le Verrou Temporel',
+                story: `# ⏳ La Porte du Temps
+
+La **Porte du Temps** se dresse devant toi, ses mécanismes battant au rythme du grand livre.
+
+*"Le temps est une arme,"* dit le Gardien du Temps. *"Apprends à verrouiller et à déverrouiller selon le défilement des blocs."*
+
+## Ta Mission
+
+Crée un coffre à verrou temporel :
+- \`lock\` — verrouille des tokens jusqu'à un numéro de séquence de grand livre donné
+- \`unlock\` — libère les tokens si la période de verrouillage est écoulée
+- \`get_lock_info\` — renvoie le moment où le verrou expire
+
+## Ce Que Tu Apprendras
+
+- La séquence / l'horodatage du grand livre pour une logique temporelle
+- L'exécution conditionnelle selon l'état de la blockchain
+- \`env.ledger().sequence()\` pour le bloc actuel
+- Les motifs de panic pour la gestion des erreurs
+
+## Concepts Clés
+
+\`\`\`rust
+env.ledger().sequence()  // Current ledger sequence number
+panic!("message")        // Abort with error
+\`\`\``,
+                learningGoal: 'Implémente une logique conditionnelle basée sur le temps en utilisant la séquence du grand livre',
+                hints: [
+                    'Utilise `env.ledger().sequence()` pour obtenir le numéro de grand livre actuel',
+                    'Compare : `if current_seq < unlock_at { panic!("Still locked"); }`',
+                    'Nettoie le stockage après le déverrouillage : `env.storage().instance().remove(&key)`',
                 ],
             },
         },
@@ -903,6 +1118,46 @@ env.storage().instance().set(&signer_key, &true);
                     'En create_pact: almacena la descripción, el número requerido y un conteo inicial de firmas de 0',
                     'En sign_pact: lee el conteo actual, increméntalo en 1, guárdalo de nuevo',
                     'En is_complete: compara signed >= required',
+                ],
+            },
+            fr: {
+                title: 'Pacte Multipartite',
+                story: `# 🤝 La Salle des Pactes
+
+Tu as atteint la **Salle des Pactes**, le défi final avant de gagner ta place parmi les Gardiens.
+
+*"Le véritable pouvoir des contrats intelligents,"* déclare le Grand Ancien, *"c'est qu'ils permettent la confiance entre inconnus."*
+
+## Ta Mission
+
+Crée un contrat d'accord à signatures multiples :
+- \`create_pact\` — crée un accord nécessitant N signatures
+- \`sign_pact\` — permet à une partie de signer l'accord
+- \`is_complete\` — vérifie si toutes les signatures requises ont été réunies
+- \`get_signers\` — renvoie qui a signé
+
+## Ce Que Tu Apprendras
+
+- Les structures de données complexes dans les contrats
+- L'autorisation multipartite
+- Le comptage et le suivi avec le stockage
+- La construction de motifs de gouvernance du monde réel
+
+## Concepts Clés
+
+\`\`\`rust
+// Track signer count
+let count: u32 = env.storage().instance()
+    .get(&SIGNER_COUNT).unwrap_or(0);
+
+// Store with dynamic keys
+env.storage().instance().set(&signer_key, &true);
+\`\`\``,
+                learningGoal: 'Construis un contrat de pacte à signatures multiples avec une gestion d\'état complexe',
+                hints: [
+                    'Dans create_pact : stocke la description, le nombre requis et un décompte initial de signatures à 0',
+                    'Dans sign_pact : lis le décompte actuel, incrémente-le de 1, enregistre-le à nouveau',
+                    'Dans is_complete : compare signed >= required',
                 ],
             },
         },
@@ -1089,6 +1344,52 @@ env.storage().instance().set(&BALANCES, &balances);
                     'Para deposit: obtén el saldo actual, suma el monto, guarda de nuevo',
                 ],
             },
+            fr: {
+                title: 'Gestionnaire de Coffre',
+                story: `# 🏦 La Forteresse de Données
+
+Au-delà de la Salle des Pactes s'étend la **Forteresse de Données**, où d'innombrables soldes d'utilisateurs sont stockés et protégés.
+
+*"Un seul solde est trivial,"* dit l'Architecte du Coffre. *"En gérer beaucoup — voilà l'art de l'architecture de stockage."*
+
+## Ta Mission
+
+Construis un contrat de coffre qui gère plusieurs soldes d'utilisateurs :
+- \`deposit\` — ajoute des fonds au solde d'un utilisateur (l'utilisateur doit s'authentifier)
+- \`withdraw\` — retire des fonds du solde d'un utilisateur (l'utilisateur doit s'authentifier)
+- \`get_balance\` — renvoie le solde actuel d'un utilisateur
+
+## Ce Que Tu Apprendras
+
+- \`Map<Address, i128>\` pour un état multi-utilisateur
+- \`Env::require_auth()\` pour l'autorisation par utilisateur
+- Le stockage persistant avec des clés complexes
+- Les motifs d'arithmétique sûre
+
+## Concepts Clés
+
+\`\`\`rust
+// Map for multiple balances
+let mut balances: Map<Address, i128> = env.storage()
+    .instance()
+    .get(&BALANCES)
+    .unwrap_or(Map::new(&env));
+
+// Per-user auth
+user.require_auth();
+
+// Update and persist
+balances.set(user, &(current + amount));
+env.storage().instance().set(&BALANCES, &balances);
+\`\`\``,
+                learningGoal: 'Construis un coffre multi-utilisateur avec le motif de stockage Map',
+                hints: [
+                    'Utilise Map<Address, i128> pour stocker les soldes des utilisateurs',
+                    'Appelle user.require_auth() avant de modifier le solde d\'un utilisateur',
+                    'Lis le Map depuis le stockage avec .unwrap_or(Map::new(&env))',
+                    'Pour deposit : récupère le solde actuel, ajoute le montant, enregistre à nouveau',
+                ],
+            },
         },
         template: `#![no_std]
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Map, i128};
@@ -1265,6 +1566,50 @@ keys.push_back(key);
                     'Añade nuevas claves con keys.push_back(key)',
                 ],
             },
+            fr: {
+                title: 'Émetteur d\'Événements',
+                story: `# 📡 La Balise de Signaux
+
+Tout en haut de la Forteresse de Données se dresse la **Balise de Signaux**, diffusant des événements à travers le réseau Stellar.
+
+*"Les contrats qui parlent sont des contrats que l'on comprend,"* dit le Gardien de la Balise. *"Les événements permettent au monde de savoir ce qui s'est passé."*
+
+## Ta Mission
+
+Crée un contrat qui stocke des données clé-valeur et émet des événements à chaque changement d'état :
+- \`set_value\` — stocke une valeur et émet un événement avec la clé et la valeur
+- \`get_value\` — récupère une valeur stockée par sa clé
+- \`get_all_keys\` — renvoie toutes les clés stockées
+
+## Ce Que Tu Apprendras
+
+- \`env.events().publish()\` pour émettre des événements
+- \`Vec<Symbol>\` pour le suivi dynamique des clés
+- L'architecture de contrats basée sur les événements
+- Les motifs de publication-abonnement sur Stellar
+
+## Concepts Clés
+
+\`\`\`rust
+// Emit an event
+env.events().publish(
+    &symbol_short!("set_value"),
+    (key, value),
+);
+
+// Track keys in a Vec
+let mut keys = env.storage().instance()
+    .get(&KEYS)
+    .unwrap_or(Vec::new(&env));
+keys.push_back(key);
+\`\`\``,
+                learningGoal: 'Implémente l\'émission d\'événements dans un contrat de stockage clé-valeur',
+                hints: [
+                    'Utilise env.events().publish() avec un sujet Symbol et les données de l\'événement',
+                    'Utilise Vec<Symbol> pour suivre toutes les clés stockées',
+                    'Ajoute de nouvelles clés avec keys.push_back(key)',
+                ],
+            },
         },
         template: `#![no_std]
 use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol, Vec, IntoVal};
@@ -1425,6 +1770,46 @@ env.storage().instance().get(&(owner, spender))
                     'Usa una tupla (Address, Address) como clave de almacenamiento compuesta',
                     'En approve: almacena la autorización para el par (owner, spender)',
                     'En transfer_from: require_auth del spender, verifica autorización, decrementa, actualiza saldos',
+                ],
+            },
+            fr: {
+                title: 'Gestionnaire d\'Approbations',
+                story: `# ✋ La Chambre de la Délégation
+
+Au sein de la Forteresse de Données repose la **Chambre de la Délégation**, où la confiance se formalise par des allocations.
+
+*"Tu ne peux pas toujours agir toi-même,"* explique le Maître de la Délégation. *"Parfois, tu dois habiliter les autres à agir en ton nom."*
+
+## Ta Mission
+
+Construis un contrat qui permet aux utilisateurs d'autoriser d'autres à dépenser en leur nom :
+- \`approve\` — le propriétaire autorise un dépensier pour un montant donné
+- \`transfer_from\` — le dépensier transfère du propriétaire vers un destinataire
+- \`allowance\` — vérifie combien un dépensier est autorisé à dépenser
+
+## Ce Que Tu Apprendras
+
+- Les motifs clé-valeur imbriqués (propriétaire -> dépensier -> allocation)
+- L'autorisation déléguée
+- Les clés de stockage à double adresse
+- Le motif de décrémentation d'allocation
+
+## Concepts Clés
+
+\`\`\`rust
+// Compound storage key for allowances
+let allowance_key = (owner.clone(), spender.clone());
+env.storage().instance().set(&allowance_key, &amount);
+
+// Read nested allowance
+env.storage().instance().get(&(owner, spender))
+    .unwrap_or(0)
+\`\`\``,
+                learningGoal: 'Implémente un système d\'allocation et de transfert délégué',
+                hints: [
+                    'Utilise un tuple (Address, Address) comme clé de stockage composée',
+                    'Dans approve : stocke l\'allocation pour la paire (owner, spender)',
+                    'Dans transfer_from : require_auth du spender, vérifie l\'allocation, décrémente-la, mets à jour les soldes',
                 ],
             },
         },
@@ -1591,6 +1976,52 @@ if env.ledger().sequence() > deadline { panic!("Campaign ended"); }
                     'En init: almacena el monto objetivo y la secuencia del ledger de la fecha límite',
                     'En contribute: verifica que la fecha límite no haya pasado, añade el monto al total',
                     'En check_goal: compara el total recaudado contra el objetivo',
+                ],
+            },
+            fr: {
+                title: 'Campagne de Financement Participatif',
+                story: `# 🎯 L'Arène du Crowdforge
+
+Tu entres dans l'**Arène du Crowdforge**, où la puissance collective donne vie aux idées.
+
+*"Seul, tu es fort,"* annonce le Commissaire-priseur. *"Ensemble, vous pouvez déplacer des étoiles. Construis une campagne que le peuple peut financer."*
+
+## Ta Mission
+
+Crée un contrat de financement participatif :
+- \`init\` — définit l'objectif de financement et la date limite (séquence du grand livre)
+- \`contribute\` — ajoute des fonds d'un contributeur
+- \`check_goal\` — renvoie true si les contributions totales >= objectif
+- \`get_total_raised\` — renvoie le total des fonds collectés
+
+## Ce Que Tu Apprendras
+
+- La séquence du grand livre pour les échéances basées sur le temps
+- L'accumulation de fonds de type séquestre
+- Le suivi d'objectifs avec des vérifications conditionnelles
+- La gestion d'état avec plusieurs contributeurs
+
+## Concepts Clés
+
+\`\`\`rust
+// Track total raised
+let total: i128 = env.storage().instance()
+    .get(&TOTAL_RAISED)
+    .unwrap_or(0);
+
+env.storage().instance().set(&TOTAL_RAISED, &(total + amount));
+
+// Check deadline
+let deadline: u32 = env.storage().instance()
+    .get(&DEADLINE)
+    .unwrap_or(0);
+if env.ledger().sequence() > deadline { panic!("Campaign ended"); }
+\`\`\``,
+                learningGoal: 'Construis un contrat de financement participatif avec suivi d\'objectif et d\'échéance',
+                hints: [
+                    'Dans init : stocke le montant objectif et la séquence de grand livre de la date limite',
+                    'Dans contribute : vérifie que la date limite n\'est pas passée, ajoute le montant au total',
+                    'Dans check_goal : compare le total collecté à l\'objectif',
                 ],
             },
         },
@@ -1768,6 +2199,50 @@ arbiter.require_auth();
                     'En deposit: require_auth del comprador y almacena el monto',
                     'En release: require_auth del árbitro, transfiere al vendedor',
                     'En refund: require_auth del árbitro, devuelve al comprador',
+                ],
+            },
+            fr: {
+                title: 'Agent de Séquestre',
+                story: `# 🤲 L'Échange de Confiance
+
+Au plus profond de l'Arène du Crowdforge se trouve l'**Échange de Confiance**, où les transactions entre inconnus sont arbitrées.
+
+*"La confiance est la monnaie la plus rare,"* dit le Médiateur du Séquestre. *"Construis un système qui retient la valeur jusqu'à ce que les conditions soient remplies."*
+
+## Ta Mission
+
+Crée un contrat de séquestre avec acheteur, vendeur et arbitre :
+- \`init\` — configure le séquestre avec les adresses de l'acheteur, du vendeur et de l'arbitre
+- \`deposit\` — l'acheteur dépose des fonds dans le séquestre
+- \`release\` — l'arbitre libère les fonds au vendeur
+- \`refund\` — l'arbitre rembourse l'acheteur
+
+## Ce Que Tu Apprendras
+
+- L'initialisation de contrats multipartites
+- Les motifs d'autorisation à trois acteurs
+- La machine à états pour le cycle de vie du séquestre
+- Les motifs de résolution de litiges
+
+## Concepts Clés
+
+\`\`\`rust
+// Multi-party init
+pub fn init(env: Env, buyer: Address, seller: Address, arbiter: Address) {
+    env.storage().instance().set(&BUYER, &buyer);
+    env.storage().instance().set(&SELLER, &seller);
+    env.storage().instance().set(&ARBITER, &arbiter);
+}
+
+// Arbiter-only functions
+arbiter.require_auth();
+\`\`\``,
+                learningGoal: 'Implémente un contrat de séquestre multipartite avec résolution de litiges',
+                hints: [
+                    'Dans init : stocke les adresses de l\'acheteur, du vendeur et de l\'arbitre',
+                    'Dans deposit : require_auth de l\'acheteur et stocke le montant',
+                    'Dans release : require_auth de l\'arbitre, transfère au vendeur',
+                    'Dans refund : require_auth de l\'arbitre, rembourse à l\'acheteur',
                 ],
             },
         },
@@ -1948,6 +2423,48 @@ if env.ledger().sequence() >= next_billing {
                     'En subscribe: almacena el plan, establece next_billing a sequence + intervalo',
                     'En collect: verifica si sequence >= next_billing, si es así cobra y actualiza next_billing',
                     'En cancel: limpia los datos de suscripción del almacenamiento',
+                ],
+            },
+            fr: {
+                title: 'Gestionnaire d\'Abonnements',
+                story: `# 🔄 Le Moteur Récurrent
+
+Au cœur du district des Protocoles Avancés ronronne le **Moteur Récurrent**, alimentant des accords périodiques automatisés.
+
+*"Les contrats les plus puissants sont ceux qui fonctionnent sans attention constante,"* dit le Gardien du Moteur. *"Construis un abonnement qui collecte des paiements récurrents."*
+
+## Ta Mission
+
+Crée un contrat de gestion d'abonnements :
+- \`subscribe\` — l'utilisateur s'abonne à un plan (stocke le plan, la prochaine facturation)
+- \`collect\` — collecte les frais d'abonnement si la facturation est due
+- \`cancel\` — annule l'abonnement
+- \`get_subscription\` — renvoie les informations d'abonnement d'un utilisateur
+
+## Ce Que Tu Apprendras
+
+- La logique de facturation récurrente avec la séquence du grand livre
+- La gestion de l'état des abonnements
+- Les motifs d'annulation et de remboursement
+- Les calculs d'intervalles de temps
+
+## Concepts Clés
+
+\`\`\`rust
+// Track subscription period
+let interval: u32 = 1000; // billing every ~1000 ledgers
+let next_billing: u32 = env.ledger().sequence() + interval;
+
+// Check if billing is due
+if env.ledger().sequence() >= next_billing {
+    // collect payment
+}
+\`\`\``,
+                learningGoal: 'Construis un contrat d\'abonnement récurrent avec facturation périodique',
+                hints: [
+                    'Dans subscribe : stocke le plan, définis next_billing à sequence + intervalle',
+                    'Dans collect : vérifie si sequence >= next_billing, si c\'est le cas collecte et mets à jour next_billing',
+                    'Dans cancel : nettoie les données d\'abonnement du stockage',
                 ],
             },
         },
@@ -2136,6 +2653,48 @@ env.storage().instance().set(&POOL, &(pool_bal + amount + fee));
                     'En repay: verifica que exista el préstamo, devuelve fondos más comisión al pool, limpia el préstamo',
                 ],
             },
+            fr: {
+                title: 'Pool de Prêts Flash',
+                story: `# ⚡ Le Coffre de l'Éclair
+
+Dans la couche la plus profonde de la Citadelle repose le **Coffre de l'Éclair**, où le capital se déplace à la vitesse de la lumière.
+
+*"Les prêts flash sont l'épreuve ultime de la conception de contrats,"* dit l'Archonte de l'Éclair. *"Emprunte, utilise et rembourse en une seule transaction."*
+
+## Ta Mission
+
+Construis un pool de prêts flash simplifié :
+- \`init\` — définit le solde du pool
+- \`flash_loan\` — emprunte au pool (doit être remboursé au sein de l'appel)
+- \`get_pool_balance\` — renvoie le solde actuel du pool
+- \`repay\` — rembourse le montant emprunté plus de petits frais
+
+## Ce Que Tu Apprendras
+
+- La mécanique des prêts flash (simplifiée pour la validation)
+- La gestion du solde du pool
+- Le suivi du cycle de vie du prêt
+- Les motifs de frais au remboursement
+
+## Concepts Clés
+
+\`\`\`rust
+// Track active loan
+let loan: i128 = env.storage().instance()
+    .get(&(borrower.clone(), LOAN_AMOUNT))
+    .unwrap_or(0);
+
+// Repay with fee
+let fee = amount / 100; // 1% fee
+env.storage().instance().set(&POOL, &(pool_bal + amount + fee));
+\`\`\``,
+                learningGoal: 'Construis un contrat de pool de prêts flash simplifié',
+                hints: [
+                    'Dans init : stocke le solde initial du pool',
+                    'Dans flash_loan : vérifie que le pool en a assez, déduis du pool, enregistre le prêt',
+                    'Dans repay : vérifie que le prêt existe, rends les fonds plus les frais au pool, nettoie le prêt',
+                ],
+            },
         },
         template: `#![no_std]
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, i128, Symbol};
@@ -2310,6 +2869,49 @@ env.storage().instance()
                     'En has_role: verifica si la clave del rol existe y es true',
                 ],
             },
+            fr: {
+                title: 'RBAC des Permissions',
+                story: `# 🛡️ Le Hall des Rôles
+
+Au-delà du Coffre de l'Éclair s'élève le **Hall des Rôles**, où l'accès est régi par des permissions structurées.
+
+*"Tous ceux qui errent ne sont pas destinés à ouvrir toutes les portes,"* déclare le Maître des Rôles. *"Construis un système où les rôles définissent ce que l'on peut faire."*
+
+## Ta Mission
+
+Crée un contrat de contrôle d'accès basé sur les rôles :
+- \`grant_role\` — l'admin accorde un rôle à un utilisateur
+- \`revoke_role\` — l'admin révoque un rôle d'un utilisateur
+- \`has_role\` — vérifie si un utilisateur possède un rôle spécifique
+- \`get_admin\` — renvoie l'admin du contrat
+
+## Ce Que Tu Apprendras
+
+- Les motifs de contrôle d'accès basé sur les rôles (RBAC)
+- Les fonctions privilégiées réservées à l'admin
+- Les clés composées pour l'appartenance à un rôle
+- Une architecture de permissions flexible
+
+## Concepts Clés
+
+\`\`\`rust
+// Grant a role
+let role_key = (user.clone(), role.clone());
+env.storage().instance().set(&role_key, &true);
+
+// Check role membership
+env.storage().instance()
+    .get(&(user.clone(), role.clone()))
+    .unwrap_or(false)
+\`\`\``,
+                learningGoal: 'Implémente un contrat de contrôle d\'accès basé sur les rôles',
+                hints: [
+                    'Dans init : stocke l\'adresse de l\'admin',
+                    'Dans grant_role : require_auth de l\'admin, stocke l\'appartenance au rôle pour l\'utilisateur',
+                    'Dans revoke_role : require_auth de l\'admin, supprime l\'appartenance au rôle',
+                    'Dans has_role : vérifie si la clé du rôle existe et est true',
+                ],
+            },
         },
         template: `#![no_std]
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
@@ -2471,6 +3073,48 @@ pub fn update_price(env: Env, asset: Symbol, price: i128) {
                     'En get_price: busca y devuelve el precio del activo',
                     'En get_last_updated: devuelve la secuencia almacenada para el activo',
                     'En get_all_assets: usa un rastreador Vec<Symbol> similar al event-emitter',
+                ],
+            },
+            fr: {
+                title: 'Flux d\'Oracle',
+                story: `# 📊 La Flèche de l'Oracle
+
+Au sommet du district des Systèmes de Production se dresse la **Flèche de l'Oracle**, où les données hors chaîne entrent dans la blockchain.
+
+*"Les contrats intelligents sont aveugles sans données,"* dit le Sage de l'Oracle. *"Construis un pont entre les mondes on-chain et off-chain."*
+
+## Ta Mission
+
+Crée un contrat d'oracle de prix :
+- \`update_price\` — l'admin met à jour le prix d'une paire d'actifs
+- \`get_price\` — renvoie le prix actuel d'une paire d'actifs
+- \`get_last_updated\` — renvoie la dernière mise à jour du prix
+- \`get_all_assets\` — renvoie toutes les paires d'actifs suivies
+
+## Ce Que Tu Apprendras
+
+- Les motifs de flux de données d'oracle
+- Les fonctions de mise à jour réservées à l'admin
+- Le suivi d'horodatage/séquence
+- La gestion des paires d'actifs avec Vec<Symbol>
+
+## Concepts Clés
+
+\`\`\`rust
+// Store price with metadata
+pub fn update_price(env: Env, asset: Symbol, price: i128) {
+    admin.require_auth();
+    env.storage().instance().set(&asset, &price);
+    env.storage().instance()
+        .set(&(asset.clone(), TIMESTAMP), &env.ledger().sequence());
+}
+\`\`\``,
+                learningGoal: 'Construis un oracle de prix on-chain avec des mises à jour de l\'admin',
+                hints: [
+                    'Dans update_price : require_auth de l\'admin, stocke le prix et la séquence',
+                    'Dans get_price : recherche et renvoie le prix de l\'actif',
+                    'Dans get_last_updated : renvoie la séquence stockée pour l\'actif',
+                    'Dans get_all_assets : utilise un traqueur Vec<Symbol> similaire à event-emitter',
                 ],
             },
         },
@@ -2661,6 +3305,49 @@ let no_votes: u32 = /* contar votos donde value es false */
                     'En create_proposal: almacena descripción, fecha límite, conteos de sí/no',
                     'En vote: verifica que la propuesta esté activa, registra la elección del votante, actualiza los totales',
                     'En execute: verifica que la propuesta se haya aprobado (sí > no), márcala como ejecutada',
+                ],
+            },
+            fr: {
+                title: 'Gouverneur Simple',
+                story: `# 🏛️ Le Hall de la Gouvernance
+
+La chambre finale attend — le **Hall de la Gouvernance**, où le destin de tout le royaume se décide par la volonté collective.
+
+*"Les meilleurs contrats intelligents habilitent les communautés à se gouverner elles-mêmes,"* proclame le Grand Ancien. *"Construis un système où les propositions deviennent loi par le vote."*
+
+## Ta Mission
+
+Crée un contrat de gouvernance avec propositions et vote :
+- \`create_proposal\` — crée une proposition avec une description et une période de vote
+- \`vote\` — émet un vote (oui/non) sur une proposition active
+- \`execute\` — exécute une proposition si elle est adoptée
+- \`get_proposal\` — renvoie les détails de la proposition
+
+## Ce Que Tu Apprendras
+
+- Les mécanismes de gouvernance on-chain
+- Le cycle de vie d'une proposition (créer → voter → exécuter)
+- Le comptage des votes avec Map<Address, bool>
+- La logique de quorum et de seuil d'approbation
+
+## Concepts Clés
+
+\`\`\`rust
+// Track votes per proposal
+let mut votes: Map<Address, bool> = env.storage().instance()
+    .get(&VOTES)
+    .unwrap_or(Map::new(&env));
+votes.set(&voter, &support);
+
+// Count approval
+let yes_votes: u32 = /* count votes where value is true */
+let no_votes: u32 = /* count votes where value is false */
+\`\`\``,
+                learningGoal: 'Construis un système de gouvernance on-chain complet avec propositions et vote',
+                hints: [
+                    'Dans create_proposal : stocke la description, la date limite, les décomptes oui/non',
+                    'Dans vote : vérifie que la proposition est active, enregistre le choix du votant, mets à jour les totaux',
+                    'Dans execute : vérifie que la proposition est adoptée (oui > non), marque-la comme exécutée',
                 ],
             },
         },
@@ -2880,6 +3567,53 @@ env.storage().instance().set(&MUTEX, &false);
                     'Establece mutex a true antes de actualizar el saldo, false después',
                 ],
             },
+            fr: {
+                title: 'Garde de Réentrance',
+                story: `# 🛡️ La Forge des Vulnérabilités
+
+Dans les profondeurs de la Citadelle repose la **Forge des Vulnérabilités**, où les contrats brisés sont restaurés.
+
+*"La vulnérabilité la plus dangereuse dans les contrats intelligents,"* avertit le Sage de la Sécurité, *"est la réentrance. Un contrat qui appelle du code externe tout en conservant un état peut être exploité."*
+
+## Ta Mission
+
+Le contrat de coffre ci-dessous est vulnérable à la réentrance — il met à jour son solde APRÈS avoir envoyé des fonds. Ta tâche est de le corriger en utilisant un motif de **garde mutex** : un drapeau booléen qui empêche la réentrance.
+
+Le code vulnérable comporte :
+- \`withdraw\` qui envoie des fonds AVANT de mettre à jour l'état (le bug)
+- Aucune protection contre la réentrance
+
+Corrige-le en :
+1. Ajoutant une clé de stockage booléenne \`MUTEX\` initialisée à \`false\`
+2. Au début de \`withdraw\`, en la mettant à \`true\`
+3. À la fin de \`withdraw\`, en la remettant à \`false\`
+4. Vérifiant le mutex à l'entrée et en faisant panic s'il est déjà verrouillé
+
+## Ce Que Tu Apprendras
+
+- L'identification de la vulnérabilité de réentrance
+- Le motif mutex/garde pour la prévention
+- Le motif check-effects-interaction
+- Un état d'esprit de développement axé sur la sécurité
+
+## Concepts Clés
+
+\`\`\`rust
+// Mutex guard pattern
+if env.storage().instance().get(&MUTEX).unwrap_or(false) {
+    panic!("Reentrancy detected");
+}
+env.storage().instance().set(&MUTEX, &true);
+// ... vulnerable operations ...
+env.storage().instance().set(&MUTEX, &false);
+\`\`\``,
+                learningGoal: 'Corrige une vulnérabilité de réentrance en utilisant le motif de garde mutex',
+                hints: [
+                    'Ajoute une constante MUTEX : `const MUTEX: Symbol = symbol_short!("MUTEX");`',
+                    'Au début de withdraw, vérifie si mutex est true et fais panic si c\'est le cas',
+                    'Mets mutex à true avant la mise à jour du solde, à false après',
+                ],
+            },
         },
         template: `#![no_std]
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
@@ -3056,6 +3790,51 @@ env.storage().instance().set(&FEE, &new_fee);
                     'En set_fee: lee ADMIN del almacenamiento, llama a admin.require_auth()',
                     'En pause: lee ADMIN del almacenamiento, llama a admin.require_auth()',
                     'La función init está bien — ya almacena el admin correctamente',
+                ],
+            },
+            fr: {
+                title: 'Correction du Contrôle d\'Accès',
+                story: `# 🔓 La Brèche des Permissions
+
+La **Brèche des Permissions** est un terrain d'entraînement où l'on répare la logique d'autorisation défaillante.
+
+*"La deuxième vulnérabilité la plus courante,"* explique le Sage de la Sécurité, *"est l'absence de contrôle d'accès. Des fonctions qui devraient être réservées aux administrateurs sont appelables par n'importe qui."*
+
+## Ta Mission
+
+Le contrat ci-dessous stocke une adresse \`admin\` mais n'utilise JAMAIS \`require_auth()\` sur les fonctions privilégiées. Ta tâche est d'ajouter un contrôle d'accès approprié.
+
+Le code vulnérable comporte :
+- Une constante \`ADMIN\` définie mais jamais vérifiée
+- Les fonctions \`set_fee\` et \`pause\` appelables par n'importe qui
+- Aucun appel à \`require_auth()\` où que ce soit
+
+Corrige-le en :
+1. Ajoutant des vérifications \`require_auth()\` sur \`set_fee\` et \`pause\`
+2. Lisant l'adresse admin depuis le stockage avant de vérifier l'authentification
+
+## Ce Que Tu Apprendras
+
+- L'identification de la vulnérabilité de contrôle d'accès
+- Le placement correct de \`require_auth()\`
+- Les motifs de fonctions réservées à l'admin
+- Les principes de défense en profondeur
+
+## Concepts Clés
+
+\`\`\`rust
+// Correct access control
+let admin: Address = env.storage().instance().get(&ADMIN).unwrap();
+admin.require_auth();
+
+// Now perform privileged operation
+env.storage().instance().set(&FEE, &new_fee);
+\`\`\``,
+                learningGoal: 'Corrige l\'absence de contrôle d\'accès en ajoutant des vérifications require_auth()',
+                hints: [
+                    'Dans set_fee : lis ADMIN depuis le stockage, appelle admin.require_auth()',
+                    'Dans pause : lis ADMIN depuis le stockage, appelle admin.require_auth()',
+                    'La fonction init est correcte — elle stocke déjà l\'admin correctement',
                 ],
             },
         },

--- a/src/i18n/index.jsx
+++ b/src/i18n/index.jsx
@@ -13,10 +13,11 @@ import React, {
 
 import en from './locales/en.json';
 import es from './locales/es.json';
+import fr from './locales/fr.json';
 import { setActiveLanguage } from './languageBridge.js';
 
-const LOCALES = { en, es };
-const SUPPORTED = ['en', 'es'];
+const LOCALES = { en, es, fr };
+const SUPPORTED = ['en', 'es', 'fr'];
 const STORAGE_KEY = 'soroban_quest_lang';
 const DEFAULT_LANG = 'en';
 

--- a/src/i18n/languageBridge.js
+++ b/src/i18n/languageBridge.js
@@ -7,7 +7,7 @@
    needing access to React context.
    ========================================== */
 
-export const SUPPORTED_LANGS = ['en', 'es'];
+export const SUPPORTED_LANGS = ['en', 'es', 'fr'];
 export const DEFAULT_LANG = 'en';
 
 let activeLanguage = DEFAULT_LANG;

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1,0 +1,603 @@
+{
+  "languages": {
+    "en": "English",
+    "es": "Español",
+    "fr": "Français"
+  },
+  "common": {
+    "selectLanguage": "Choisir la langue",
+    "toggleTheme": "Changer de thème",
+    "back": "Retour",
+    "close": "Fermer",
+    "save": "Enregistrer",
+    "cancel": "Annuler",
+    "confirm": "Confirmer",
+    "loading": "Chargement…",
+    "all": "Toutes",
+    "level": "Niveau",
+    "xp": "XP",
+    "chapter": "Chapitre",
+    "mission": "Mission",
+    "complete": "Terminer",
+    "completed": "Terminée",
+    "locked": "Verrouillée",
+    "unlocked": "Déverrouillée",
+    "skipToContent": "Passer au contenu principal"
+  },
+  "navbar": {
+    "home": "Accueil",
+    "campaigns": "Campagnes",
+    "missions": "Missions",
+    "profile": "Profil",
+    "journal": "Journal",
+    "leaderboard": "Classement",
+    "achievements": "Succès",
+    "shop": "Boutique",
+    "ariaMain": "Navigation principale",
+    "ariaHome": "Aller à la page d'accueil",
+    "ariaMobile": "Menu de navigation mobile",
+    "userProfile": "Profil de l'utilisateur :",
+    "openMenu": "Ouvrir le menu de navigation",
+    "closeMenu": "Fermer le menu de navigation",
+    "replayTutorial": "Revoir le tutoriel"
+  },
+  "home": {
+    "badge": "✨ Aucune configuration • Aucun portefeuille requis • Open source",
+    "title": {
+      "lead": "Maîtrisez les",
+      "brand": "Soroban",
+      "tail": "contrats intelligents"
+    },
+    "subtitle": "Lancez-vous dans une quête épique pour apprendre la plateforme de contrats intelligents de Stellar. Écrivez du vrai code Soroban dans votre navigateur, relevez des défis et faites progresser vos compétences en blockchain — sans aucune installation.",
+    "cta": {
+      "continueQuest": "⚔️ Continuer la quête",
+      "viewProgress": "📊 Voir la progression",
+      "beginJourney": "🚀 Commencer votre aventure",
+      "viewMissionMap": "🗺️ Voir la carte des missions"
+    },
+    "stats": {
+      "missions": "Missions",
+      "totalXp": "XP total",
+      "backendNeeded": "Backend requis"
+    },
+    "howItWorks": {
+      "title": "Comment ça marche",
+      "subtitle": "Votre parcours de zéro à la maîtrise de Soroban, entièrement dans le navigateur."
+    },
+    "features": {
+      "read": {
+        "title": "Lisez la quête",
+        "body": "Chaque mission déroule une histoire tout en enseignant les concepts fondamentaux de Soroban. Découvrez les contrats, le stockage, les jetons et bien plus à travers des défis guidés par le récit."
+      },
+      "write": {
+        "title": "Écrivez le code",
+        "body": "Utilisez l'éditeur Monaco intégré avec la coloration syntaxique Rust et l'autocomplétion Soroban. Les modèles vous donnent un point de départ — à vous d'écrire la logique."
+      },
+      "test": {
+        "title": "Lancez les tests",
+        "body": "Validez votre code avec un retour instantané. Chaque mission comporte des vérifications cachées qui contrôlent la structure, les fonctions et les motifs de votre contrat."
+      },
+      "xp": {
+        "title": "Gagnez de l'XP et montez de niveau",
+        "body": "Obtenez des points d'expérience pour chaque mission terminée. Débloquez des badges, gravissez les rangs et suivez votre parcours d'Initié à Souverain Stellaire."
+      },
+      "zeroBackend": {
+        "title": "Aucun backend",
+        "body": "Tout s'exécute dans votre navigateur. Aucun serveur, aucune base de données, aucun compte. Votre progression est enregistrée localement — exportez-la à tout moment sous forme de fichier JSON."
+      },
+      "path": {
+        "title": "Parcours progressif",
+        "body": "De « Hello World » aux contrats multi-signatures. Chaque mission s'appuie sur la précédente, créant un parcours structuré vers la maîtrise de Soroban."
+      }
+    },
+    "stats": {
+      "missionsCompleted": "{{count}}/{{total}} Missions",
+      "xpEarned": "{{xp}} XP gagnés",
+      "goldEarned": "{{gold}} Or",
+      "badgesUnlocked": "{{count}} Badges",
+      "currentLevel": "Niveau {{level}} — {{rank}}",
+      "nextMission": "Mission suivante",
+      "continueFrom": "Continuer depuis {{title}}",
+      "recentActivity": "Activité récente",
+      "viewAll": "Tout voir",
+      "quickStats": "Statistiques rapides",
+      "streak": "Série de jours"
+    }
+  },
+  "footer": {
+    "platform": {
+      "heading": "Plateforme",
+      "home": "Accueil",
+      "missions": "Missions",
+      "profile": "Profil",
+      "glossary": "Glossaire"
+    },
+    "resources": {
+      "heading": "Ressources",
+      "docs": "Documentation Soroban",
+      "sdk": "SDK Stellar",
+      "github": "GitHub",
+      "glossary": "Glossaire",
+      "faq": "FAQ"
+    },
+    "community": {
+      "heading": "Communauté",
+      "discord": "Discord",
+      "telegram": "Telegram",
+      "forum": "Forum Stellar",
+      "blog": "Blog Stellar"
+    },
+    "credits": {
+      "tagline": "Conçu pour l'écosystème Stellar",
+      "license": "Licence MIT"
+    }
+  },
+  "notFound": {
+    "title": "Cette quête n'existe pas",
+    "body": "Vous semblez vous être égaré dans l'espace lointain",
+    "back": "Retourner à la base"
+  },
+  "errorBoundary": {
+    "generic": {
+      "title": "Une erreur s'est produite",
+      "body": "La quête a rencontré une erreur d'exécution. Consultez la console pour plus de détails.",
+      "reload": "Recharger",
+      "goHome": "Aller à l'accueil",
+      "report": "Signaler un problème"
+    },
+    "editor": {
+      "body": "Le chargement de l'éditeur a échoué",
+      "reset": "Réinitialiser l'éditeur"
+    },
+    "mission": {
+      "title": "Mission indisponible",
+      "retry": "Réessayer"
+    }
+  },
+  "profile": {
+    "edit": "✏️ Modifier le profil",
+    "viewJournal": "📖 Voir le journal",
+    "editPanel": {
+      "title": "Modifier le profil",
+      "nameLabel": "Nom de l'aventurier",
+      "avatarLegend": "Choisissez un avatar",
+      "namePlaceholder": "Saisir un nom"
+    },
+    "selector": {
+      "title": "Profil actif",
+      "help": "{{count}} sur {{max}} profils locaux utilisés.",
+      "meta": "Niveau {{level}} • {{xp}} XP",
+      "create": "Créer un profil",
+      "emptySlot": "Emplacement vide",
+      "defaultName": "Joueur {{number}}"
+    },
+    "stats": {
+      "missions": "Missions",
+      "badges": "Badges"
+    },
+    "sections": {
+      "badges": "🏅 Badges",
+      "completedMissions": "✅ Missions terminées",
+      "data": "⚙️ Données"
+    },
+    "noMissions": "Aucune mission terminée pour le moment.",
+    "xpBar": {
+      "current": "{{current}} / {{needed}} XP",
+      "total": "Total : {{xp}} XP"
+    },
+    "data": {
+      "export": "Exporter",
+      "import": "Importer",
+      "reset": "Réinitialiser",
+      "confirmReset": "Réinitialiser toute la progression ? Cette action est irréversible.",
+      "status": {
+        "exported": "✅ Progression exportée !",
+        "imported": "✅ Progression importée avec succès !",
+        "importFailed": "❌ Fichier invalide — importation impossible.",
+        "resetDone": "🗑️ Progression réinitialisée."
+      },
+      "toast": {
+        "exported": "Progression exportée avec succès !",
+        "imported": "Progression importée avec succès !",
+        "importFailed": "Impossible d'importer le fichier. Vérifiez le format.",
+        "resetDone": "🗑️ Progression réinitialisée."
+      },
+      "log": {
+        "exported": "Progression de l'aventure exportée",
+        "imported": "Progression de l'aventure importée depuis un fichier"
+      }
+    }
+  },
+  "leaderboard": {
+    "kicker": "Multijoueur local",
+    "title": "Classement",
+    "subtitle": "Comparez l'XP, le niveau, les missions et les badges entre vos profils locaux.",
+    "manageProfiles": "Gérer les profils",
+    "championAria": "Champion local actuel",
+    "championSummary": "Niveau {{level}} • {{xp}} XP • {{missions}} missions terminées",
+    "tableTitle": "Classement local",
+    "profileCount": "{{count}} profils",
+    "active": "Actif",
+    "switch": "Changer",
+    "columns": {
+      "rank": "Rang",
+      "player": "Joueur",
+      "xp": "XP",
+      "level": "Niveau",
+      "missions": "Missions",
+      "badges": "Badges",
+      "status": "Statut"
+    }
+  },
+  "achievements": {
+    "kicker": "Coffre à badges",
+    "title": "Succès",
+    "subtitle": "Succès débloqués et verrouillés de {{name}}.",
+    "summaryAria": "Résumé des succès obtenus",
+    "unlocked": "Débloqués",
+    "progressAria": "Progression des succès obtenus",
+    "progress": "Progression",
+    "gridAria": "Collection de badges de succès",
+    "empty": "Terminez des missions pour gagner des succès et des badges !"
+  },
+  "journal": {
+    "title": "Journal d'aventure",
+    "subtitle": "Votre parcours à travers le royaume de Soroban, consigné pour l'éternité.",
+    "clearLog": "🗑️ Effacer le journal",
+    "confirmClear": "Effacer tout l'historique d'activité ?",
+    "controlsLabel": "Recherche et filtres du journal",
+    "searchLabel": "Rechercher des entrées du journal",
+    "searchPlaceholder": "Rechercher des entrées du journal...",
+    "typeFilterLabel": "Filtrer par type d'activité",
+    "dateFilterLabel": "Filtrer par date",
+    "summary": {
+      "missions": "Missions",
+      "badges": "Badges",
+      "level": "Niveau",
+      "totalXp": "XP total",
+      "streak": "Série de jours"
+    },
+    "filters": {
+      "all": "Tout",
+      "mission": "Mission",
+      "badge": "Badge",
+      "levelUp": "Montée de niveau",
+      "hint": "Indice",
+      "system": "Système"
+    },
+    "dateFilters": {
+      "all": "N'importe quand",
+      "today": "Aujourd'hui",
+      "week": "7 derniers jours",
+      "month": "Ce mois-ci"
+    },
+    "empty": "Aucune activité enregistrée pour le moment. Commencez votre première mission !",
+    "dates": {
+      "today": "Aujourd'hui",
+      "yesterday": "Hier"
+    },
+    "events": {
+      "missionStarted": "Mission commencée : {{title}}",
+      "missionCompleted": "Mission terminée : {{title}}",
+      "badgeEarned": "Badge « {{name}} » obtenu !",
+      "levelUp": "Niveau {{level}} atteint !",
+      "hintUsed": "Indice {{index}} utilisé",
+      "export": "Progression de l'aventure exportée",
+      "import": "Progression de l'aventure importée depuis un fichier",
+      "streakOne": "Série quotidienne : 1 jour !",
+      "streakMany": "Série quotidienne : {{count}} jours !"
+    },
+    "details": {
+      "targetXp": "XP cible atteint : {{xp}}",
+      "earnedXp": "{{xp}} XP gagnés"
+    },
+    "eventLabels": {
+      "mission": "Mission",
+      "badge": "Badge",
+      "levelUp": "Montée de niveau",
+      "hint": "Indice",
+      "system": "Système",
+      "streak": "Série"
+    }
+  },
+  "campaigns": {
+    "title": "Campagnes",
+    "subtitle": "Chapitres épiques axés sur l'histoire | Niveau {{level}} | {{completed}}/{{total}} missions au total",
+    "chapter": "Chapitre {{number}}",
+    "missionCount": "{{completed}}/{{total}} missions",
+    "lockedAt": "🔒 Atteignez le niveau {{level}} pour déverrouiller",
+    "chapterComplete": "✓ Chapitre terminé !",
+    "back": "← Retour aux campagnes",
+    "completeOf": "{{completed}}/{{total}} terminées",
+    "lore": {
+      "iconLabel": "Parchemin de l'histoire du chapitre",
+      "modalTitle": "Introduction du chapitre",
+      "beginChapter": "Commencer le chapitre {{number}}"
+    }
+  },
+  "missionMap": {
+    "title": "Carte des missions",
+    "subtitle": "{{completed}} missions sur {{total}} terminées",
+    "searchPlaceholder": "Rechercher des missions…",
+    "difficulty": {
+      "all": "Toutes",
+      "beginner": "Débutant",
+      "intermediate": "Intermédiaire",
+      "advanced": "Avancé"
+    },
+    "chapters": {
+      "all": "Tous les chapitres",
+      "n": "Chapitre {{number}}"
+    },
+    "card": {
+      "chapterMission": "Chapitre {{chapter}} • Mission {{mission}}",
+      "xp": "⚡ {{xp}} XP",
+      "completed": "✓ Terminée",
+      "locked": "🔒 Verrouillée"
+    },
+    "allCompleted": {
+      "title": "Toutes les missions terminées !",
+      "body": "Félicitations, {{rank}} ! Vous avez maîtrisé l'ensemble des {{xp}} XP de défis Soroban."
+    },
+    "noResults": "Aucune mission ne correspond à vos filtres.",
+    "aria": {
+      "missionPath": "Graphique du parcours des missions",
+      "missionTimeline": "Chronologie des missions",
+      "missionItem": "Mission {{order}} : {{title}}",
+      "missionItemCompleted": "Mission {{order}} : {{title}}, terminée",
+      "missionItemUnlocked": "Mission {{order}} : {{title}}, déverrouillée",
+      "missionItemLocked": "Mission {{order}} : {{title}}, verrouillée"
+    }
+  },
+  "missionDetail": {
+    "tabs": {
+      "story": "Histoire",
+      "editor": "Éditeur",
+      "tests": "Tests",
+      "replay": "📹 Rejouer"
+    },
+    "notFound": {
+      "title": "Mission introuvable",
+      "body": "La mission « {{id}} » n'existe pas.",
+      "back": "← Retour à la carte des missions"
+    },
+    "editor": {
+      "reset": "↺ Réinitialiser",
+      "hint": "💡 Indice",
+      "solution": "👁️ Solution",
+      "run": "▶ Lancer les tests",
+      "running": "Exécution…",
+      "themeLabel": "Thème de l'éditeur"
+    },
+    "terminal": {
+      "title": "Sortie des tests",
+      "placeholder": "Cliquez sur « Lancer les tests » pour valider votre code…",
+      "runningChecks": "🔍 Exécution des vérifications…",
+      "alreadyCompleted": "🏅 Déjà terminée — aucun XP supplémentaire accordé."
+    },
+    "status": {
+      "checking": "Vérification…",
+      "passing": "{{passed}}/{{total}} vérifications réussies",
+      "allPassing": "{{passed}}/{{total}} vérifications réussies ✓",
+      "note": "vérifications en direct · suite complète au lancement des tests"
+    },
+    "toasts": {
+      "validated": "Paramètres de la mission validés !",
+      "validationFailed": "Validation échouée. Consultez le terminal.",
+      "hintUnlocked": "Indice {{index}} débloqué",
+      "codeReset": "Code réinitialisé au modèle",
+      "solutionLoaded": "Solution chargée dans l'éditeur"
+    },
+    "hint": {
+      "label": "💡 Indice {{index}} :"
+    },
+    "victory": {
+      "title": "Mission terminée !",
+      "youCompleted": "Vous avez terminé",
+      "xpGained": "+{{xp}} XP",
+      "levelUp": "🎉 Niveau supérieur ! Vous êtes maintenant Niveau {{level}} — {{rank}}",
+      "badgeEarnedOne": "🏅 Nouveau badge obtenu !",
+      "badgeEarnedMany": "🏅 Nouveaux badges obtenus !",
+      "next": "Mission suivante →",
+      "map": "Carte des missions"
+    },
+    "replay": {
+      "header": "📹 Revoyez votre solution",
+      "body": "Revisitez étape par étape votre processus de résolution.",
+      "start": "▶️ Démarrer la relecture"
+    },
+    "okashi": {
+      "button": "🚀 Essayer sur Okashi — Compiler et déployer",
+      "help": "Ouvre okashi.dev dans un nouvel onglet. Votre code est copié dans le presse-papiers — collez-le là-bas pour le compiler avec le vrai compilateur Soroban et le déployer sur Testnet."
+    }
+  },
+  "skillTree": {
+    "title": "Arbre de compétences Soroban",
+    "subtitle": "Suivez votre maîtrise des concepts des contrats intelligents Soroban",
+    "overall": "{{unlocked}}/{{total}} concepts maîtrisés",
+    "categoryProgress": "{{unlocked}}/{{total}}",
+    "categories": {
+      "Core": {
+        "title": "Concepts fondamentaux",
+        "description": "Composants fondamentaux de Soroban"
+      },
+      "Storage": {
+        "title": "Stockage et état",
+        "description": "Gestion des données persistantes"
+      },
+      "Types": {
+        "title": "Types de données",
+        "description": "Travailler avec différents types de données"
+      },
+      "Auth": {
+        "title": "Autorisation",
+        "description": "Contrôle d'accès et sécurité"
+      },
+      "Events": {
+        "title": "Événements",
+        "description": "Émission et gestion des événements de contrat"
+      },
+      "Protocols": {
+        "title": "Protocoles",
+        "description": "Motifs de protocoles DeFi du monde réel"
+      },
+      "DeFi": {
+        "title": "DeFi",
+        "description": "Primitives de finance décentralisée"
+      }
+    },
+    "tooltip": {
+      "chapter": "Chapitre {{chapter}}"
+    },
+    "modal": {
+      "taughtIn": "Enseigné dans : {{title}}",
+      "chapterLabel": "Chapitre :",
+      "difficultyLabel": "Difficulté :",
+      "xpLabel": "Récompense XP :",
+      "learningGoal": "Objectif d'apprentissage :",
+      "completed": "✅ Terminée",
+      "notCompleted": "🔒 Pas encore terminée",
+      "startMission": "Commencer la mission",
+      "notCovered": "Ce concept n'est pas encore couvert par les missions disponibles."
+    }
+  },
+  "ranks": {
+    "0": "Initié",
+    "1": "Apprenti",
+    "2": "Scribe",
+    "3": "Codeur",
+    "4": "Architecte",
+    "5": "Sentinelle",
+    "6": "Gardien",
+    "7": "Maître Gardien",
+    "8": "Ancien",
+    "9": "Luminaire",
+    "10": "Souverain Stellaire"
+  },
+  "difficulty": {
+    "beginner": "débutant",
+    "intermediate": "intermédiaire",
+    "advanced": "avancé"
+  },
+  "badges": {
+    "first_contract": {
+      "name": "Premier contrat",
+      "description": "Terminez votre première mission"
+    },
+    "triple_threat": {
+      "name": "Triple menace",
+      "description": "Terminez 3 missions"
+    },
+    "five_star": {
+      "name": "Cinq étoiles",
+      "description": "Terminez 5 missions"
+    },
+    "completionist": {
+      "name": "Complétiste",
+      "description": "Terminez toutes les missions"
+    },
+    "level_3": {
+      "name": "Étoile montante",
+      "description": "Atteignez le niveau 3"
+    },
+    "level_5": {
+      "name": "Gardien Stellaire",
+      "description": "Atteignez le niveau 5"
+    },
+    "xp_1000": {
+      "name": "Amasseur d'XP",
+      "description": "Gagnez 1000 XP"
+    },
+    "speed_demon": {
+      "name": "Démon de vitesse",
+      "description": "Terminez une mission du premier coup"
+    },
+    "chapter_1": {
+      "name": "Éveil",
+      "description": "Terminez toutes les missions du Chapitre 1"
+    },
+    "chapter_2": {
+      "name": "Gardien de la mémoire",
+      "description": "Terminez toutes les missions du Chapitre 2"
+    },
+    "chapter_3": {
+      "name": "Maître forgeron",
+      "description": "Terminez toutes les missions du Chapitre 3"
+    },
+    "chapter_4": {
+      "name": "Architecte de données",
+      "description": "Terminez toutes les missions du Chapitre 4"
+    },
+    "chapter_5": {
+      "name": "Pionnier des protocoles",
+      "description": "Terminez toutes les missions du Chapitre 5"
+    },
+    "chapter_6": {
+      "name": "Maître de production",
+      "description": "Terminez toutes les missions du Chapitre 6"
+    },
+    "chapter_7": {
+      "name": "Sentinelle de sécurité",
+      "description": "Terminez toutes les missions du Chapitre 7"
+    }
+  },
+  "shop": {
+    "title": "Boutique",
+    "subtitle": "Dépensez votre Or en avatars, boosts et badges",
+    "ariaCategories": "Filtres de catégories de la boutique",
+    "categories": {
+      "all": "Tous",
+      "avatars": "Avatars",
+      "boosts": "Boosts",
+      "badges": "Badges"
+    },
+    "items": {
+      "avatarPack1": "Pack d'avatars 1",
+      "avatarPack1Desc": "Débloquez 5 nouvelles options d'avatar",
+      "avatarPack2": "Pack d'avatars 2",
+      "avatarPack2Desc": "Débloquez 5 options d'avatar exclusives",
+      "xpBoost": "Boost d'XP",
+      "xpBoostDesc": "Doublez l'XP de votre prochaine mission",
+      "streakFreeze": "Gel de série",
+      "streakFreezeDesc": "Protégez votre série pour un jour manqué",
+      "hintToken": "Jeton d'indice",
+      "hintTokenDesc": "Révélez un indice sans pénalité d'XP",
+      "premiumBadge": "Badge premium",
+      "premiumBadgeDesc": "Badge premium exclusif pour votre profil"
+    },
+    "buy": "Acheter",
+    "purchased": "Acheté",
+    "alreadyPurchased": "Vous possédez déjà cet article",
+    "insufficientFunds": "Pas assez d'Or pour acheter cet article",
+    "purchaseSuccess": "{{item}} acheté avec succès !",
+    "empty": "Aucun article trouvé dans cette catégorie",
+    "ariaPurchase": "Acheter {{item}} pour {{price}} Or",
+    "ariaPurchased": "{{item}} - Déjà acheté"
+  },
+  "onboarding": {
+    "step1": {
+      "title": "Bienvenue dans Soroban Quest !",
+      "body": "Lancez-vous dans une aventure ludique pour maîtriser le développement de contrats intelligents Soroban. Terminez des missions, gagnez de l'XP et de l'Or, et débloquez des succès."
+    },
+    "step2": {
+      "title": "Votre centre de progression",
+      "body": "La barre de navigation affiche votre niveau, votre XP, votre solde d'Or et votre profil. Utilisez-la pour naviguer entre les Missions, les Campagnes, le Profil, le Journal et plus encore."
+    },
+    "step3": {
+      "title": "Carte des missions et quêtes",
+      "body": "La carte des missions présente toutes les quêtes organisées par chapitre. Chaque mission propose un défi de codage Soroban avec une histoire, des indices et une validation automatisée."
+    },
+    "step4": {
+      "title": "Éditeur de code et validation",
+      "body": "Écrivez du code Rust Soroban dans l'éditeur Monaco intégré. Lancez des tests pour vérifier votre solution par rapport aux motifs de validation. Aucun serveur de compilation requis !"
+    },
+    "step5": {
+      "title": "Progression RPG",
+      "body": "Gagnez de l'XP et de l'Or pour chaque mission terminée. Montez de niveau pour débloquer de nouveaux rangs, chapitres et badges. Dépensez votre Or dans la Boutique pour des objets cosmétiques et des boosts."
+    },
+    "dismiss": "Compris !",
+    "next": "Suivant",
+    "prev": "Retour",
+    "skip": "Passer le tutoriel"
+  }
+}


### PR DESCRIPTION
## Summary

Adds full **French (fr)** localization support, resolving #218.

French now appears in the language selector, is picked up by browser language auto-detection, and every user-facing string — UI, missions, and campaign lore — renders in French.

## Changes

- **`src/i18n/locales/fr.json`** — new locale file with complete key parity to `en.json` (389 keys: navigation, page titles, buttons, achievements/badges, shop items, error messages, toasts, onboarding, etc.). Adds `languages.fr = "Français"`.
- **`src/i18n/index.jsx`** — register `fr` in `LOCALES` and `SUPPORTED`. This is sufficient for both the language selector dropdown (data-driven) and browser auto-detection (`detectBrowserLanguage()` iterates `SUPPORTED`).
- **`src/i18n/languageBridge.js`** — add `fr` to `SUPPORTED_LANGS` so the non-React mission/campaign data loaders localize against French.
- **`src/data/missions.js`** — add an `fr` i18n block to all **19 missions** (`title`, `story`, `learningGoal`, `hints`).
- **`src/data/campaigns.js`** — add an `fr` i18n block to all **7 campaigns** (`title`, `description`, `lore`).

The `LanguageSelector.jsx` needed no change — it renders from the data-driven `languages` list, so French appears automatically once registered.

## Translation notes

- Rust/Soroban code blocks, inline code spans, and identifiers (`Env`, `Symbol`, `require_auth`, `panic!(...)`, etc.) kept verbatim — only prose translated.
- Placeholders (`{{var}}`), emojis, markdown structure, and template-literal backtick-escaping preserved exactly.
- Consistent terminology (e.g. Guardian → Gardien, smart contract → contrat intelligent, storage → stockage, reentrancy → réentrance, escrow → séquestre).

## Verification

- ✅ `en.json` ↔ `fr.json` key parity: 0 missing keys.
- ✅ `npm run build` (Vite production build) passes.
- ✅ `eslint` passes with no errors or warnings.

closes #218
