### PR TITLE
feat: add Midnight Protocol and Nebula editor themes (#221)

### DIFF
--- a/src/systems/__tests__/editorThemes.test.js
+++ b/src/systems/__tests__/editorThemes.test.js
@@ -28,7 +28,7 @@ describe("editorThemes", () => {
   describe("definitions", () => {
     it("defines between 3 and 5 themes with unique ids", () => {
       expect(EDITOR_THEMES.length).toBeGreaterThanOrEqual(3);
-      expect(EDITOR_THEMES.length).toBeLessThanOrEqual(5);
+      expect(EDITOR_THEMES.length).toBeLessThanOrEqual(10); // updated: 7 themes after Midnight Protocol + Nebula additions
       const ids = EDITOR_THEMES.map((theme) => theme.id);
       expect(new Set(ids).size).toBe(ids.length);
     });

--- a/src/systems/editorThemes.js
+++ b/src/systems/editorThemes.js
@@ -76,6 +76,78 @@ export const EDITOR_THEMES = [
       },
     },
   },
+  {
+    // Deep navy/dark-blue background with cyan + magenta accents.
+    // Cyberpunk aesthetic designed for extended coding sessions (low eye strain).
+    id: "midnight-protocol",
+    label: "Midnight Protocol",
+    builtin: false,
+    data: {
+      base: "vs-dark",
+      inherit: true,
+      rules: [
+        { token: "comment",   foreground: "4a5568", fontStyle: "italic" },
+        { token: "keyword",   foreground: "00d4ff" }, // electric cyan
+        { token: "string",    foreground: "ff79c6" }, // magenta/pink
+        { token: "number",    foreground: "bd93f9" }, // soft purple
+        { token: "type",      foreground: "50fa7b" }, // neon green
+        { token: "function",  foreground: "8be9fd" }, // light cyan
+        { token: "variable",  foreground: "f8f8f2" }, // near-white
+        { token: "operator",  foreground: "ff79c6" }, // magenta
+        { token: "delimiter", foreground: "6272a4" }, // muted blue-grey
+      ],
+      colors: {
+        "editor.background":               "#0a0e1a",
+        "editor.foreground":               "#cdd6f4",
+        "editor.lineHighlightBackground":  "#111827",
+        "editor.selectionBackground":      "#1e3a5f",
+        "editor.inactiveSelectionBackground": "#162840",
+        "editorLineNumber.foreground":     "#3d4f6e",
+        "editorLineNumber.activeForeground": "#00d4ff",
+        "editorCursor.foreground":         "#ff79c6",
+        "editorIndentGuide.background":    "#1e2a3a",
+        "editorWidget.background":         "#0d1525",
+        "editorSuggestWidget.background":  "#0d1525",
+        "editorSuggestWidget.border":      "#1e3a5f",
+      },
+    },
+  },
+  {
+    // Purple/violet background with warm orange + cool blue syntax highlights.
+    // Inspired by space nebula imagery — fits the Stellar blockchain theme.
+    id: "nebula",
+    label: "Nebula",
+    builtin: false,
+    data: {
+      base: "vs-dark",
+      inherit: true,
+      rules: [
+        { token: "comment",   foreground: "6272a4", fontStyle: "italic" },
+        { token: "keyword",   foreground: "ff9d00" }, // warm amber/orange
+        { token: "string",    foreground: "69d2e7" }, // cool cyan-blue
+        { token: "number",    foreground: "ff6b6b" }, // soft coral
+        { token: "type",      foreground: "c792ea" }, // lavender
+        { token: "function",  foreground: "82aaff" }, // periwinkle blue
+        { token: "variable",  foreground: "e1e4f0" }, // near-white lavender
+        { token: "operator",  foreground: "ff9d00" }, // warm amber
+        { token: "delimiter", foreground: "7b7fb5" }, // muted indigo
+      ],
+      colors: {
+        "editor.background":               "#12103a",
+        "editor.foreground":               "#e1e4f0",
+        "editor.lineHighlightBackground":  "#1a1752",
+        "editor.selectionBackground":      "#2d2a6e",
+        "editor.inactiveSelectionBackground": "#211e55",
+        "editorLineNumber.foreground":     "#443f7a",
+        "editorLineNumber.activeForeground": "#ff9d00",
+        "editorCursor.foreground":         "#c792ea",
+        "editorIndentGuide.background":    "#1e1b4b",
+        "editorWidget.background":         "#0e0c2e",
+        "editorSuggestWidget.background":  "#0e0c2e",
+        "editorSuggestWidget.border":      "#2d2a6e",
+      },
+    },
+  },
 ];
 
 export const DEFAULT_THEME_ID = "vs-dark";


### PR DESCRIPTION
## Summary

Resolves #221 — adds two new custom Monaco editor themes to expand the visual options beyond the existing 5.

---

### Midnight Protocol
- **Background:** `#0a0e1a` — deep navy/dark blue
- **Cursor:** magenta `#ff79c6`
- **Keywords:** electric cyan `#00d4ff`
- **Strings:** magenta/pink `#ff79c6`
- **Numbers:** soft purple `#bd93f9`
- **Types:** neon green `#50fa7b`
- **Functions:** light cyan `#8be9fd`
- Inspired by cyberpunk aesthetics; low eye-strain for extended sessions

### Nebula
- **Background:** `#12103a` — deep purple/violet
- **Cursor:** lavender `#c792ea`
- **Keywords:** warm amber `#ff9d00`
- **Strings:** cool cyan-blue `#69d2e7`
- **Numbers:** soft coral `#ff6b6b`
- **Types:** lavender `#c792ea`
- **Functions:** periwinkle blue `#82aaff`
- Inspired by space nebula imagery; fits the Stellar blockchain theme

---

## Changes

- `src/systems/editorThemes.js` — two new entries appended to `EDITOR_THEMES`; each defines a complete token rule set (keyword, string, number, type, function, variable, operator, delimiter, comment) and extended editor colors (selection, line-number highlight, widget backgrounds, indent guides)
- `src/systems/__tests__/editorThemes.test.js` — updated stale `toBeLessThanOrEqual(5)` bound to `10` (7 themes now exist)

## What was NOT changed

- `MissionDetail.jsx` — theme selector already iterates `EDITOR_THEMES` dynamically; no changes needed
- Storage layer — `loadEditorTheme` / `saveEditorTheme` / `isValidThemeId` all derive from `EDITOR_THEMES`; persistence works automatically

## Testing

- All 133 unit tests pass (`npm run test`)
- Both themes registered via the existing `registerEditorThemes(monaco)` call on editor mount
- Theme selection persists in `localStorage` via the existing infrastructure