### PR TITLE
feat: add dedicated Quest Catalog page and navigation route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,29 +1,30 @@
-import React, { lazy, Suspense, useEffect } from "react";
-import { Routes, Route } from "react-router-dom";
-import Navbar from "./components/Navbar";
-import Footer from "./components/Footer";
+import React, { lazy, Suspense, useEffect } from 'react';
+import { Routes, Route } from 'react-router-dom';
+import Navbar from './components/Navbar';
+import Footer from './components/Footer';
 
-import useScrollToTop from "./hooks/useScrollToTop";
-import { ErrorBoundary } from "./components/ErrorBoundary";
-import { ToastProvider } from "./systems/ToastContext";
-import { GameStateProvider } from "./systems/GameStateContext";
-import LoadingScreen from "./components/LoadingScreen";
-import { loadProgress, saveProgress } from "./systems/storage";
-import { updateStreak } from "./systems/gameEngine";
-import "./systems/Toast.css";
+import useScrollToTop from './hooks/useScrollToTop';
+import { ErrorBoundary } from './components/ErrorBoundary';
+import { ToastProvider } from './systems/ToastContext';
+import { GameStateProvider } from './systems/GameStateContext';
+import LoadingScreen from './components/LoadingScreen';
+import { loadProgress, saveProgress } from './systems/storage';
+import { updateStreak } from './systems/gameEngine';
+import './systems/Toast.css';
 
 // Lazy load page components
-const Home = lazy(() => import("./pages/Home"));
-const MissionMap = lazy(() => import("./pages/MissionMap"));
-const MissionDetail = lazy(() => import("./pages/MissionDetail"));
-const Profile = lazy(() => import("./pages/Profile"));
-const Journal = lazy(() => import("./pages/Journal"));
-const Campaigns = lazy(() => import("./pages/Campaigns"));
-const SkillTree = lazy(() => import("./pages/SkillTree"));
-const Leaderboard = lazy(() => import("./pages/Leaderboard"));
-const Achievements = lazy(() => import("./pages/Achievements"));
-const Shop = lazy(() => import("./pages/Shop"));
-const NotFound = lazy(() => import("./pages/NotFound"));
+const Home = lazy(() => import('./pages/Home'));
+const MissionMap = lazy(() => import('./pages/MissionMap'));
+const MissionDetail = lazy(() => import('./pages/MissionDetail'));
+const Quests = lazy(() => import('./pages/Quests')); // Added Quests page
+const Profile = lazy(() => import('./pages/Profile'));
+const Journal = lazy(() => import('./pages/Journal'));
+const Campaigns = lazy(() => import('./pages/Campaigns'));
+const SkillTree = lazy(() => import('./pages/SkillTree'));
+const Leaderboard = lazy(() => import('./pages/Leaderboard'));
+const Achievements = lazy(() => import('./pages/Achievements'));
+const Shop = lazy(() => import('./pages/Shop'));
+const NotFound = lazy(() => import('./pages/NotFound'));
 
 export default function App() {
   // Global React Router navigation scroll management
@@ -46,6 +47,7 @@ export default function App() {
                 <Routes>
                   <Route path="/" element={<Home />} />
                   <Route path="/missions" element={<MissionMap />} />
+                  <Route path="/quests" element={<Quests />} /> {/* Added /quests route */}
                   <Route path="/campaigns" element={<Campaigns />} />
                   <Route path="/mission/:missionId" element={<MissionDetail />} />
                   <Route path="/profile" element={<Profile />} />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect, useRef } from "react";
-import { Link, useLocation } from "react-router-dom";
-import { Menu, X, Sun, Moon } from "lucide-react";
-import { useTranslation } from "../i18n/useTranslation";
-import { useGameState } from "../systems/GameStateContext";
-import LanguageSelector from "./LanguageSelector";
-import { resetOnboarding } from "./Onboarding";
+import React, { useState, useEffect, useRef } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { Menu, X, Sun, Moon } from 'lucide-react';
+import { useTranslation } from '../i18n/useTranslation';
+import { useGameState } from '../systems/GameStateContext';
+import LanguageSelector from './LanguageSelector';
+import { resetOnboarding } from './Onboarding';
 
 export default function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
@@ -17,16 +17,14 @@ export default function Navbar() {
 
   const [theme, setTheme] = useState(() => {
     return (
-      localStorage.getItem("soroban_quest_theme") ||
-      (window.matchMedia("(prefers-color-scheme: light)").matches
-        ? "light"
-        : "dark")
+      localStorage.getItem('soroban_quest_theme') ||
+      (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark')
     );
   });
 
   useEffect(() => {
-    document.documentElement.setAttribute("data-theme", theme);
-    localStorage.setItem("soroban_quest_theme", theme);
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('soroban_quest_theme', theme);
   }, [theme]);
 
   // Close the language dropdown on outside click or Escape
@@ -38,18 +36,18 @@ export default function Navbar() {
       }
     };
     const onKey = (e) => {
-      if (e.key === "Escape") setLangOpen(false);
+      if (e.key === 'Escape') setLangOpen(false);
     };
-    document.addEventListener("mousedown", onClick);
-    document.addEventListener("keydown", onKey);
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onKey);
     return () => {
-      document.removeEventListener("mousedown", onClick);
-      document.removeEventListener("keydown", onKey);
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onKey);
     };
   }, [langOpen]);
 
   const toggleTheme = () => {
-    setTheme((prev) => (prev === "light" ? "dark" : "light"));
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
   };
 
   const handleLanguageChange = (code) => {
@@ -57,61 +55,66 @@ export default function Navbar() {
     setLangOpen(false);
   };
 
-  const isActive = (path) => (location.pathname === path ? "active" : "");
+  const isActive = (path) => (location.pathname === path ? 'active' : '');
 
-return (
+  return (
     <>
       {/* SKIP TO CONTENT LINK (#102) */}
       <a href="#main-content" className="skip-to-content">
-        {t("common.skipToContent")}
+        {t('common.skipToContent')}
       </a>
 
-      <nav className="navbar" aria-label={t("navbar.ariaMain")}>
+      <nav className="navbar" aria-label={t('navbar.ariaMain')}>
         {/* LOGO */}
-        <Link to="/" className="navbar-logo" aria-label={t("navbar.ariaHome")}>
+        <Link to="/" className="navbar-logo" aria-label={t('navbar.ariaHome')}>
           <span className="navbar-logo-text">SOROBAN QUEST</span>
         </Link>
 
         {/* LINKS */}
         <ul className="navbar-links">
           <li>
-            <Link to="/" className={isActive("/")}>
-              {t("navbar.home")}
+            <Link to="/" className={isActive('/')}>
+              {t('navbar.home')}
             </Link>
           </li>
           <li>
-            <Link to="/campaigns" className={isActive("/campaigns")}>
-              {t("navbar.campaigns")}
+            <Link to="/campaigns" className={isActive('/campaigns')}>
+              {t('navbar.campaigns')}
             </Link>
           </li>
           <li>
-            <Link to="/missions" className={isActive("/missions")}>
-              {t("navbar.missions")}
+            <Link to="/missions" className={isActive('/missions')}>
+              {t('navbar.missions')}
             </Link>
           </li>
           <li>
-            <Link to="/profile" className={isActive("/profile")}>
-              {t("navbar.profile")}
+            <Link to="/quests" className={isActive('/quests')}>
+              {t('navbar.quests')}
             </Link>
           </li>
           <li>
-            <Link to="/journal" className={isActive("/journal")}>
-              {t("navbar.journal")}
+            <Link to="/profile" className={isActive('/profile')}>
+              {t('navbar.profile')}
             </Link>
           </li>
           <li>
-            <Link to="/leaderboard" className={isActive("/leaderboard")}>
-              {t("navbar.leaderboard")}
+            <Link to="/journal" className={isActive('/journal')}>
+              {t('navbar.journal')}
             </Link>
           </li>
           <li>
-            <Link to="/achievements" className={isActive("/achievements")}>
-              {t("navbar.achievements")}
+            <Link to="/leaderboard" className={isActive('/leaderboard')}>
+              {t('navbar.leaderboard')}
             </Link>
           </li>
           <li>
-            <Link to="/shop" className={isActive("/shop")}>
-              {t("navbar.shop")}
+            <Link to="/achievements" className={isActive('/achievements')}>
+              {t('navbar.achievements')}
+            </Link>
+          </li>
+          <li>
+            <Link to="/shop" className={isActive('/shop')}>
+              {t('navbar.shop')}
             </Link>
           </li>
         </ul>
@@ -132,16 +135,16 @@ return (
           <button
             onClick={toggleTheme}
             className="btn-ghost"
-            style={{ padding: "0.5rem", borderRadius: "50%" }}
-            aria-label={t("common.toggleTheme")}
+            style={{ padding: '0.5rem', borderRadius: '50%' }}
+            aria-label={t('common.toggleTheme')}
           >
-            {theme === "light" ? <Moon size={20} /> : <Sun size={20} />}
+            {theme === 'light' ? <Moon size={20} /> : <Sun size={20} />}
           </button>
           <span className="text-xl" aria-hidden="true">
             {profile.avatar}
           </span>
           <span className="text-sm font-semibold">
-            <span className="sr-only">{t("navbar.userProfile")} </span>
+            <span className="sr-only">{t('navbar.userProfile')} </span>
             {profile.name}
           </span>
           <span className="navbar-gold" title={`${progress.gold || 0} gold`}>
@@ -150,9 +153,9 @@ return (
           <button
             onClick={resetOnboarding}
             className="btn-ghost"
-            style={{ padding: "0.25rem 0.5rem", fontSize: "0.75rem" }}
-            title={t("navbar.replayTutorial")}
-            aria-label={t("navbar.replayTutorial")}
+            style={{ padding: '0.25rem 0.5rem', fontSize: '0.75rem' }}
+            title={t('navbar.replayTutorial')}
+            aria-label={t('navbar.replayTutorial')}
           >
             🎓
           </button>
@@ -162,7 +165,7 @@ return (
         <button
           onClick={() => setIsOpen(!isOpen)}
           className="hamburger-btn"
-          aria-label={isOpen ? t("navbar.closeMenu") : t("navbar.openMenu")}
+          aria-label={isOpen ? t('navbar.closeMenu') : t('navbar.openMenu')}
           aria-expanded={isOpen}
         >
           {isOpen ? <X /> : <Menu />}
@@ -173,34 +176,37 @@ return (
 
         {/* MOBILE MENU */}
         <div
-          className={`mobile-menu ${isOpen ? "open" : ""}`}
-          aria-label={t("navbar.ariaMobile")}
+          className={`mobile-menu ${isOpen ? 'open' : ''}`}
+          aria-label={t('navbar.ariaMobile')}
           aria-hidden={!isOpen}
-          inert={!isOpen ? "" : undefined}
+          inert={!isOpen ? '' : undefined}
         >
           <Link to="/" onClick={() => setIsOpen(false)}>
-            {t("navbar.home")}
+            {t('navbar.home')}
           </Link>
           <Link to="/campaigns" onClick={() => setIsOpen(false)}>
-            {t("navbar.campaigns")}
+            {t('navbar.campaigns')}
           </Link>
           <Link to="/missions" onClick={() => setIsOpen(false)}>
-            {t("navbar.missions")}
+            {t('navbar.missions')}
+          </Link>
+          <Link to="/quests" onClick={() => setIsOpen(false)}>
+            {t('navbar.quests')}
           </Link>
           <Link to="/profile" onClick={() => setIsOpen(false)}>
-            {t("navbar.profile")}
+            {t('navbar.profile')}
           </Link>
           <Link to="/journal" onClick={() => setIsOpen(false)}>
-            {t("navbar.journal")}
+            {t('navbar.journal')}
           </Link>
           <Link to="/leaderboard" onClick={() => setIsOpen(false)}>
-            {t("navbar.leaderboard")}
+            {t('navbar.leaderboard')}
           </Link>
           <Link to="/achievements" onClick={() => setIsOpen(false)}>
-            {t("navbar.achievements")}
+            {t('navbar.achievements')}
           </Link>
           <Link to="/shop" onClick={() => setIsOpen(false)}>
-            {t("navbar.shop")}
+            {t('navbar.shop')}
           </Link>
 
           {/* MOBILE EXTRAS */}
@@ -219,10 +225,10 @@ return (
             <button
               onClick={toggleTheme}
               className="btn-ghost"
-              style={{ padding: "0.5rem", borderRadius: "50%" }}
-              aria-label={t("common.toggleTheme")}
+              style={{ padding: '0.5rem', borderRadius: '50%' }}
+              aria-label={t('common.toggleTheme')}
             >
-              {theme === "light" ? <Moon size={20} /> : <Sun size={20} />}
+              {theme === 'light' ? <Moon size={20} /> : <Sun size={20} />}
             </button>
             <span aria-hidden="true">{profile.avatar}</span>
             <span>{profile.name}</span>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -25,6 +25,7 @@
   },
   "navbar": {
     "home": "Home",
+    "quests": "Quests",
     "campaigns": "Campaigns",
     "missions": "Missions",
     "profile": "Profile",
@@ -39,6 +40,21 @@
     "openMenu": "Open navigation menu",
     "closeMenu": "Close navigation menu",
     "replayTutorial": "Replay Tutorial"
+  },
+  "quests": {
+    "title": "Quest Catalog",
+    "subtitle": "Browse, search, and filter all available missions.",
+    "searchPlaceholder": "Search missions...",
+    "allCampaigns": "All Campaigns",
+    "allDifficulties": "All Difficulties",
+    "beginner": "Beginner",
+    "intermediate": "Intermediate",
+    "advanced": "Advanced",
+    "allStatus": "All Status",
+    "completed": "Completed",
+    "incomplete": "Incomplete",
+    "done": "Done",
+    "noResults": "No missions found matching your criteria."
   },
   "home": {
     "badge": "✨ Zero setup • No wallet needed • Open source",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -25,6 +25,7 @@
   },
   "navbar": {
     "home": "Inicio",
+    "quests": "Búsquedas",
     "campaigns": "Campañas",
     "missions": "Misiones",
     "profile": "Perfil",
@@ -39,6 +40,21 @@
     "openMenu": "Abrir menú de navegación",
     "closeMenu": "Cerrar menú de navegación",
     "replayTutorial": "Repetir tutorial"
+  },
+  "quests": {
+    "title": "Catálogo de Misiones",
+    "subtitle": "Explora, busca y filtra todas las misiones disponibles.",
+    "searchPlaceholder": "Buscar misiones...",
+    "allCampaigns": "Todas las Campañas",
+    "allDifficulties": "Todas las Dificultades",
+    "beginner": "Principiante",
+    "intermediate": "Intermedio",
+    "advanced": "Avanzado",
+    "allStatus": "Todos los Estados",
+    "completed": "Completadas",
+    "incomplete": "Incompletas",
+    "done": "Hecho",
+    "noResults": "No se encontraron misiones que coincidan con tus criterios."
   },
   "home": {
     "badge": "✨ Sin configuración • Sin billetera • Código abierto",

--- a/src/pages/Quests.css
+++ b/src/pages/Quests.css
@@ -1,0 +1,224 @@
+.quests-container {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.quests-header {
+  margin-bottom: 2rem;
+}
+
+.quests-header h1 {
+  font-size: 1.875rem;
+  font-weight: 700;
+  color: var(--text-color, #ffffff);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.5rem 0;
+}
+
+.quests-title-icon {
+  color: #f59e0b;
+}
+
+.quests-header p {
+  color: var(--text-muted, #9ca3af);
+  margin: 0;
+}
+
+/* Filters & Search Toolbar */
+.quests-filters {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+@media (min-width: 640px) {
+  .quests-filters {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .quests-filters {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.quests-search-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.quests-search-icon {
+  position: absolute;
+  left: 0.75rem;
+  color: var(--text-muted, #9ca3af);
+}
+
+.quests-input,
+.quests-select {
+  width: 100%;
+  background-color: var(--bg-card, #111827);
+  border: 1px solid var(--border-color, #374151);
+  border-radius: 0.5rem;
+  padding: 0.625rem 1rem;
+  color: var(--text-color, #ffffff);
+  font-size: 0.875rem;
+  outline: none;
+  transition: border-color 0.2s;
+  box-sizing: border-box;
+}
+
+.quests-input {
+  padding-left: 2.5rem;
+}
+
+.quests-input:focus,
+.quests-select:focus {
+  border-color: #6366f1;
+}
+
+.quests-select option {
+  background-color: var(--bg-card, #111827);
+  color: var(--text-color, #ffffff);
+}
+
+/* Mission Card Grid */
+.quests-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .quests-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .quests-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.quest-card {
+  background-color: var(--bg-card, #111827);
+  border: 1px solid var(--border-color, #1f2937);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  text-decoration: none;
+  transition: all 0.2s ease-in-out;
+}
+
+.quest-card:hover {
+  border-color: rgba(99, 102, 241, 0.5);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 25px -5px rgba(99, 102, 241, 0.1);
+}
+
+.quest-card-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.quest-campaign-badge {
+  background-color: rgba(49, 46, 129, 0.5);
+  color: #a5b4fc;
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  font-size: 0.75rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: 9999px;
+  font-weight: 500;
+}
+
+.quest-completed-badge {
+  background-color: rgba(6, 78, 59, 0.5);
+  color: #34d399;
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  font-size: 0.75rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: 9999px;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-weight: 500;
+}
+
+.quest-card-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-color, #ffffff);
+  margin: 0 0 0.5rem 0;
+  transition: color 0.2s;
+}
+
+.quest-card:hover .quest-card-title {
+  color: #818cf8;
+}
+
+.quest-card-desc {
+  color: var(--text-muted, #9ca3af);
+  font-size: 0.875rem;
+  margin: 0 0 1rem 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.quest-card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-color, #1f2937);
+  font-size: 0.875rem;
+}
+
+.quest-difficulty {
+  color: var(--text-muted, #9ca3af);
+  text-transform: capitalize;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.quest-xp {
+  color: #fbbf24;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+/* Empty State */
+.quests-empty {
+  text-align: center;
+  padding: 4rem 1rem;
+  background-color: rgba(17, 24, 39, 0.5);
+  border: 1px solid var(--border-color, #1f2937);
+  border-radius: 1rem;
+  margin-top: 1rem;
+}
+
+.quests-empty-icon {
+  color: var(--text-muted, #4b5563);
+  margin-bottom: 0.75rem;
+}
+
+.quests-empty p {
+  color: var(--text-muted, #9ca3af);
+  font-weight: 500;
+  margin: 0;
+}

--- a/src/pages/Quests.jsx
+++ b/src/pages/Quests.jsx
@@ -120,7 +120,7 @@ export default function Quests() {
         </select>
       </div>
 
-      {/* Mission Card Grid matching UI Reference */}
+
       <div className="quests-grid">
         {filteredMissions.map((mission) => {
           const { title } = getLocalizedMission(mission);

--- a/src/pages/Quests.jsx
+++ b/src/pages/Quests.jsx
@@ -1,0 +1,163 @@
+import React, { useState, useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { Search, CheckCircle, Clock, Trophy, Filter } from 'lucide-react';
+import { useTranslation } from '../i18n/useTranslation';
+import { useGameState } from '../systems/GameStateContext';
+import { missions } from '../data/missions';
+import './Quests.css';
+
+export default function Quests() {
+  const { t, language } = useTranslation();
+  const { progress } = useGameState();
+
+  const allMissions = missions || [];
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedCampaign, setSelectedCampaign] = useState('all');
+  const [selectedDifficulty, setSelectedDifficulty] = useState('all');
+  const [completionStatus, setCompletionStatus] = useState('all');
+
+  const getLocalizedMission = (mission) => {
+    const langData = mission.i18n?.[language] || mission.i18n?.en || {};
+    return {
+      title: langData.title || mission.id,
+      description: langData.story || langData.description || '',
+    };
+  };
+
+  const uniqueCampaigns = useMemo(() => {
+    const campaignsSet = new Set(allMissions.map((m) => m.campaign || m.chapter).filter(Boolean));
+    return Array.from(campaignsSet);
+  }, [allMissions]);
+
+  const filteredMissions = useMemo(() => {
+    return allMissions.filter((mission) => {
+      const { title, description } = getLocalizedMission(mission);
+      const matchesSearch =
+        title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        description.toLowerCase().includes(searchQuery.toLowerCase());
+
+      const campaignKey = mission.campaign || String(mission.chapter);
+      const matchesCampaign =
+        selectedCampaign === 'all' || campaignKey === String(selectedCampaign);
+
+      const matchesDifficulty =
+        selectedDifficulty === 'all' || mission.difficulty === selectedDifficulty;
+
+      const isCompleted = mission.completed || progress.completedMissions?.includes(mission.id);
+      const matchesCompletion =
+        completionStatus === 'all' ||
+        (completionStatus === 'completed' && isCompleted) ||
+        (completionStatus === 'incomplete' && !isCompleted);
+
+      return matchesSearch && matchesCampaign && matchesDifficulty && matchesCompletion;
+    });
+  }, [
+    allMissions,
+    searchQuery,
+    selectedCampaign,
+    selectedDifficulty,
+    completionStatus,
+    progress,
+    language,
+  ]);
+
+  return (
+    <div id="main-content" className="quests-container">
+      {/* Page Header */}
+      <div className="quests-header">
+        <h1>
+          <Trophy className="quests-title-icon" size={28} /> {t('quests.title', 'Quest Catalog')}
+        </h1>
+        <p>{t('quests.subtitle', 'Browse, search, and filter all available missions.')}</p>
+      </div>
+
+      {/* Filter and Search Toolbar */}
+      <div className="quests-filters">
+        <div className="quests-search-wrapper">
+          <Search className="quests-search-icon" size={18} />
+          <input
+            type="text"
+            placeholder={t('quests.searchPlaceholder', 'Search missions...')}
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="quests-input"
+          />
+        </div>
+
+        <select
+          value={selectedCampaign}
+          onChange={(e) => setSelectedCampaign(e.target.value)}
+          className="quests-select"
+        >
+          <option value="all">{t('quests.allCampaigns', 'All Campaigns')}</option>
+          {uniqueCampaigns.map((campaign) => (
+            <option key={campaign} value={campaign}>
+              Chapter {campaign}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={selectedDifficulty}
+          onChange={(e) => setSelectedDifficulty(e.target.value)}
+          className="quests-select"
+        >
+          <option value="all">{t('quests.allDifficulties', 'All Difficulties')}</option>
+          <option value="beginner">{t('quests.beginner', 'Beginner')}</option>
+          <option value="intermediate">{t('quests.intermediate', 'Intermediate')}</option>
+          <option value="advanced">{t('quests.advanced', 'Advanced')}</option>
+        </select>
+
+        <select
+          value={completionStatus}
+          onChange={(e) => setCompletionStatus(e.target.value)}
+          className="quests-select"
+        >
+          <option value="all">{t('quests.allStatus', 'All Status')}</option>
+          <option value="completed">{t('quests.completed', 'Completed')}</option>
+          <option value="incomplete">{t('quests.incomplete', 'Incomplete')}</option>
+        </select>
+      </div>
+
+      {/* Mission Card Grid matching UI Reference */}
+      <div className="quests-grid">
+        {filteredMissions.map((mission) => {
+          const { title } = getLocalizedMission(mission);
+          const isCompleted = mission.completed || progress.completedMissions?.includes(mission.id);
+          const campaignBadgeText = mission.campaign || `Chapter ${mission.chapter || 1}`;
+
+          return (
+            <Link key={mission.id} to={`/mission/${mission.id}`} className="quest-card">
+              <div className="quest-card-top">
+                <span className="quest-campaign-badge">{campaignBadgeText}</span>
+                {isCompleted && (
+                  <span className="quest-completed-badge">
+                    <CheckCircle size={14} /> {t('quests.done', 'Completed')}
+                  </span>
+                )}
+              </div>
+
+              <h3 className="quest-card-title">{title}</h3>
+
+              <div className="quest-card-footer">
+                <span className="quest-difficulty">
+                  <Clock size={14} /> {mission.difficulty || 'Beginner'}
+                </span>
+                <span className="quest-xp">+{mission.xpReward || 100} XP</span>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+
+      {/* Empty State */}
+      {filteredMissions.length === 0 && (
+        <div className="quests-empty">
+          <Filter className="quests-empty-icon" size={40} />
+          <p>{t('quests.noResults', 'No missions found matching your criteria.')}</p>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #216

What does this PR do:
This pull request introduces the brand new Quest Catalog (/quests) page to Soroban Quest. It allows players to view all available missions in a centralized, responsive card grid layout inspired by NodeGuardians.io, moving away from relying solely on the campaign mission map.

Key features added:
[x] Created Quests.jsx and Quests.css for a fully responsive mission grid.
[x] Implemented robust search functionality filtering missions by title and description.
[x] Added interactive filter controls for campaign chapters, difficulty levels (Beginner, Intermediate, Advanced), and completion status (Completed/Incomplete).
[x] Integrated localized mission support (EN/ES) matching the application's i18n structure.
[x] Updated desktop and mobile Navbar.jsx with the /quests route link.

Type of change:
[x] New feature

Testing checklist:
[x] npm run build passes
[x] npm run lint passes (if available)
[x] Tested locally in the browser
[x] All existing pages still work correctly